### PR TITLE
Enable a demo of the admin panel + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Quick EVerest Demos
 
-This repository is a repackaging of several simple demos of the [EVerest](https://lfenergy.org/projects/everest/) tech stack. Our intent is to showcase the foundational layers of a charging solution that could address interoperability and reliability issues in the industry. EVerest is currently in the _early adoption_ stage of the [LF Energy Technical Project Lifecycle](https://wiki.lfenergy.org/display/HOME/Technical+Project+Lifecycle).
+This repository is a repackaging of several simple demos of the EVerest tech stack. Our intent is to showcase the foundational layers of a charging solution that could address interoperability and reliability issues in the industry. EVerest is currently in the _early adoption_ stage of the [LF Energy Technical Project Lifecycle](https://wiki.lfenergy.org/display/HOME/Technical+Project+Lifecycle).
 
 ## What is EVerest?
 [EVerest](https://lfenergy.org/projects/everest/) is a [Linux Foundation Energy](https://lfenergy.org/) project aiming to provide a modular, open-source framework and tech stack for all manner of electric vehicle chargers. This mission and architecture mean EVerest is well positioned to serve as the base for a reference implementation of a variety of standards that can drive interoperability in the eMobility space.
 
 ### Vision
-The Joint Office plans to use EVerest as a baseline from which to collaboratively build reliable interoperability solutions for EV charging, including:
+The [US Joint Office of Energy and Transportation (US-JOET)](https://driveelectric.gov/) plans to use EVerest as a baseline from which to collaboratively build reliable interoperability solutions for EV charging, including:
 - reference implementations for standards driving interoperability between network actors including EVs, EVSEs, and CSMSs
 - interoperability testing tools and test suites
 - simulated EVs, EVSEs, etc. following interoperability best practices.
+
+The US-JOET has contributed this repository to the base everest project and continue modifying it to explore additional configurations.
 
 ### EVerest currently supports the following standards
 - EN 61851
@@ -24,7 +26,6 @@ The Joint Office plans to use EVerest as a baseline from which to collaborativel
 - Full OCPP 2.0.1 / 2.1
 - ISO 15118-20
 - Robust error handling/reporting
-
 
 ## SETUP: access docker
 
@@ -45,9 +46,9 @@ The use cases supported by the three demos are summarized in conceptual block di
 
 ### STEP 1: Run the demo
 - Copy and paste the command for the demo you want to see:
-    - 🚨simple AC charging station ⚡: `curl -o docker-compose.yml https://raw.githubusercontent.com/US-JOET/everest-demo/main/docker-compose.yml && docker compose -p everest up`
-    - 🚨ISO 15118 DC charging ⚡: `curl -o docker-compose.yml https://raw.githubusercontent.com/US-JOET/everest-demo/main/docker-compose.iso15118-dc.yml && docker compose -p everest-dc up`
-    - 🚨 two EVSE charging ⚡: `curl -o docker-compose.yml https://raw.githubusercontent.com/US-JOET/everest-demo/main/docker-compose.two-evse.yml && docker compose -p everest-two-evse up`
+    - 🚨simple AC charging station ⚡: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.yml && docker compose -p everest up`
+    - 🚨ISO 15118 DC charging ⚡: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.iso15118-dc.yml && docker compose -p everest-dc up`
+    - 🚨 two EVSE charging ⚡: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.two-evse.yml && docker compose -p everest-two-evse up`
 
 ### STEP 2: Interact with the demo
 - Open the `nodered` flows to understand the module flows at http://127.0.0.1:1880
@@ -61,9 +62,15 @@ The use cases supported by the three demos are summarized in conceptual block di
 ### STEP 3: See the list of modules loaded and the high level message exchange
 ![Simple AC charging station log screenshot](img/simple_ac_charging_station.png)
 
+### OPTIONAL: Explore the configs visually
+- This demo can be run independently, and exports [the admin panel](https://everest.github.io/nightly/general/03_quick_start_guide.html#admin-panel-and-simulations) as explained [in this video](https://youtu.be/OJ6kjHRPkyY?t=904).It provides a visual representation of the configuration and the resulting configurations.
+- Run the demo: 💄 exploring configs 🔧: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.admin-panel.yml && docker compose -p everest-admin-panel up`
+- Access the visual representation at http://localhost:8849
+
 ### TEARDOWN: Clean up after the demo
 - Kill the demo process
-- Delete files and containers: `docker compose -p everest down && rm docker-compose.yml`
+- Delete files and containers: `docker compose -p [prefix] down && rm docker-compose.yml`
+where `[prefix]` is `everest, everest-dc, everest-two-evse...`
 
 ## High level block diagram overview of EVerest capabilities
 From https://everest.github.io/nightly/general/01_framework.html

--- a/docker-compose.admin-panel.yml
+++ b/docker-compose.admin-panel.yml
@@ -1,0 +1,19 @@
+version: "3.6"
+
+services:
+  mqtt-server:
+    image: ghcr.io/shankari/everest-demo/mqtt-server:0.0.1
+    logging:
+      driver: none
+
+  manager:
+    image: ghcr.io/shankari/everest-demo/manager:0.0.2
+    depends_on:
+      - mqtt-server
+    environment:
+      - MQTT_SERVER_ADDRESS=mqtt-server
+    ports:
+      - 8849:8849
+    entrypoint: "sh ./build/run-scripts/run-sil.sh"
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0


### PR DESCRIPTION
- add a new demo to display the admin panel
- update the README to:
  - change the download location to the base everest repo instead of US-JOET
  - clarify what the Joint Office is and that it will continue to contribute in this space
  - add section on launching the optional demo and displaying the admin panel
  - Modify the teardown to handle the case that there is no longer only one prefix