### PR TITLE
Basic CI/CD

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,60 @@
+name: cicd
+
+on:
+  push:
+    branches:
+      - 'build_pkg_**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  docker-build-and-push-images:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: ghcr.io/us-joet/everest-demo/manager
+            context: ./manager
+          - image: ghcr.io/us-joet/everest-demo/mqtt-server
+            context: ./mosquitto
+          - image: ghcr.io/us-joet/everest-demo/nodered
+            context: ./nodered
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Log into GitHub container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- build on every PR and merge
- if there is a push to a branch starting with `build_pkg`, automatically build and push new images to the organization and attach them to the repo

Author: Shankari <shankari@eecs.berkeley.edu>
Date:   Thu Oct 26 11:04:46 2023 -0700

    Remove pushes on `main` to avoid extraneous double push

    with the current flow, we build on `build_pkg_`
    once the packages are built, we will merge to main
    we don't want to rebuild on main

Author: Shankari <shankari@eecs.berkeley.edu>
Date:   Thu Oct 26 10:28:54 2023 -0700

    Give package write permissions to this job as well

Author: Shankari <shankari@eecs.berkeley.edu>
Date:   Thu Oct 26 10:16:07 2023 -0700

    Actually enable the new workflow for `build_pkg` branches

Author: Dan Moore <9156191+drmrd@users.noreply.github.com>
Date:   Thu Oct 26 11:50:23 2023 -0400

    Build Docker images on PR, merge, and tag events