### PR TITLE
Correct the tags output by the Docker metadata action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -84,9 +84,7 @@ jobs:
         with:
           images: ${{ matrix.host_namespace }}/${{ matrix.image_name }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern=${{ steps.docker-image-version-check.outputs.TAG }}
+            type=semver,pattern={{version}},value=v${{ steps.docker-image-version-check.outputs.TAG }}
 
       - name: Log into GitHub container registry
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Corrects the `docker/metadata-action` in our CI/CD workflow so that the tag in our `.env` file is used to label new Docker images.

Closes EVerest/EVerest#119