### PR TITLE
Turn on basic testing

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -20,5 +20,6 @@ jobs:
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash
+        timeout-minutes: 10
         run: |
           curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp201.sh | bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -14,9 +14,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest]
 
     steps:
+      - name: Setup Docker on macOS using Colima, Lima-VM, and Homebrew.
+        uses: douglascamata/setup-docker-macos-action@v1-alpha # Uses an action in the root directory
+        id: docker-install
+      - name: Verify install
+        id: docker-verify
+        shell: bash
+        run: |
+          docker --version
+          docker compose --version
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -27,6 +27,7 @@ jobs:
           docker --version
           docker compose version
           colima --version
+          mkdir -p /var/folders
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -29,6 +29,6 @@ jobs:
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: |
           curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp201.sh | bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -1,0 +1,20 @@
+name: e2etest
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 4 * * *'
+
+jobs:
+  pull-and-run-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Download and launch
+        id: curl-download-and-launch
+        shell: bash
+        run: |
+          curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp201.sh | bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: |
           docker --version
-          docker compose --version
+          docker compose version
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -29,6 +29,6 @@ jobs:
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp201.sh | bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Download and launch

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -26,6 +26,7 @@ jobs:
         run: |
           docker --version
           docker compose version
+          colima --version
       - name: Download and launch
         id: curl-download-and-launch
         shell: bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -22,4 +22,4 @@ jobs:
         shell: bash
         timeout-minutes: 10
         run: |
-          timeout curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp201.sh | bash
+          curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp201.sh | bash

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -1,6 +1,10 @@
 name: e2etest
 
 on:
+  pull_request:
+    branches:
+      - main
+
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '5 4 * * *'


### PR DESCRIPTION
I _wanted_ to turn on the automated tests that we have, but it fails because pytest is not installed. @couryrr-afs can you please fix the automated tests so we can include them as well.

<details>
<summary>Existing automated e2e tests fail</summary>

```
$ bash demo-automated-testing.sh
[+] Building 0.0s (0/0)                                    docker:desktop-linux
[+] Running 2/0
 ✔ Container everest-ac-demo-mqtt-server-1  Created                        0.0s
 ✔ Container everest-ac-demo-manager-1      Created                        0.0s
Attaching to everest-ac-demo-manager-1, everest-ac-demo-mqtt-server-1
everest-ac-demo-mqtt-server-1  | 1710048535: mosquitto version 2.0.10 starting
everest-ac-demo-mqtt-server-1  | 1710048535: Config loaded from /mosquitto/config/mosquitto.conf.
everest-ac-demo-mqtt-server-1  | 1710048535: Opening ipv4 listen socket on port 1883.
everest-ac-demo-mqtt-server-1  | 1710048535: Opening websockets listen socket on port 9001.
everest-ac-demo-mqtt-server-1  | 1710048535: mosquitto version 2.0.10 running
everest-ac-demo-manager-1      | ./run-test.sh: line 3: pytest: not found
everest-ac-demo-manager-1 exited with code 127
```
</details>