### PR TITLE
Revert "Bump mosquitto version"

### DIFF
--- a/mosquitto/Dockerfile
+++ b/mosquitto/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-mosquitto:2.0.16
+FROM eclipse-mosquitto:2.0.10
 
 COPY mosquitto.conf /mosquitto/config/mosquitto.conf
 


### PR DESCRIPTION
This reverts commit 669333f47100fcefb0bb53f576a4abc466bdb9ea.

Andy by extension EVerest/everest-demo#24

This change breaks the simulation on OSX
With version 0.010 I get

```
everest-demo-manager-1      | 2024-03-11 06:23:24.525848 [INFO] token_validator  :: Module token_validator initialized [5602ms]
everest-demo-mqtt-server-1  | 1710138204: New client connected from 172.18.0.3:32950 as auto-73D95491-B9F6-E212-92CF-AE5FA8804007 (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138205: New connection from 172.18.0.3:58592 on port 1883.
everest-demo-mqtt-server-1  | 1710138205: New client connected from 172.18.0.3:58592 as auto-F180A549-19C1-0C16-393D-07FBE833252C (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138205: New connection from 172.18.0.3:58606 on port 1883.
everest-demo-mqtt-server-1  | 1710138205: New client connected from 172.18.0.3:58606 as auto-EFAD2115-ACD2-C543-1D7C-F37E02AB88B9 (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138205: New connection from 172.18.0.3:58616 on port 1883.
everest-demo-mqtt-server-1  | 1710138205: New client connected from 172.18.0.3:58616 as auto-946F8C23-C2AE-0B54-F1CB-9AFCCADB9D02 (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138206: New connection from 172.18.0.3:58624 on port 1883.
everest-demo-mqtt-server-1  | 1710138206: New client connected from 172.18.0.3:58624 as auto-534F95F3-778D-F6C8-D28E-72D5C0ADBD6B (p2, c1, k400).
everest-demo-manager-1      | 2024-03-11 06:23:26.512910 [INFO] manager          :: 🚙🚙🚙 All modules are initialized. EVerest up and running [9433ms] 🚙🚙🚙
everest-demo-manager-1      | 2024-03-11 06:23:28.195674 [INFO] connector_1:Evs  :: Max AC hardware capabilities: 32A/3ph
everest-demo-manager-1      | 2024-03-11 06:23:28.411117 [INFO] connector_1:Evs  :: AC HLC mode enabled.
everest-demo-manager-1      | 2024-03-11 06:23:28.411518 [INFO] connector_1:Evs  :: 🌀🌀🌀 Ready to start charging 🌀🌀🌀
```

With 0.0.11, I get

```
everest-demo-manager-1      | 2024-03-11 06:25:06.484763 [INFO] grid_connection  :: Module grid_connection_point initialized [6698ms]
everest-demo-mqtt-server-1  | 1710138306: New client connected from 172.21.0.3:36662 as auto-9C772817-5157-BCD2-5DF8-5E29F5415B84 (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138306: New connection from 172.21.0.3:36674 on port 1883.
everest-demo-mqtt-server-1  | 1710138306: New client connected from 172.21.0.3:36674 as auto-7712B4EC-F402-53D2-0740-6FEFE3A871D2 (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138306: New connection from 172.21.0.3:36676 on port 1883.
everest-demo-manager-1      |
everest-demo-manager-1      | 2024-03-11 06:25:06.686385 [INFO] iso15118_charge  :: TCP server on eth0 is listening on port [fe80::42:acff:fe15:3%417]:61341
everest-demo-manager-1      |
everest-demo-manager-1      | 2024-03-11 06:25:06.686703 [INFO] iso15118_charge  :: TLS server on eth0 is listening on port [fe80::42:acff:fe15:3%417]:64109
everest-demo-manager-1      |
everest-demo-manager-1      | 2024-03-11 06:25:06.686761 [INFO] iso15118_charge  :: SDP socket setup succeeded
everest-demo-mqtt-server-1  | 1710138306: New client connected from 172.21.0.3:36676 as auto-6EA9FFB4-75BB-7D6D-6409-B67B7E22F821 (p2, c1, k400).
everest-demo-manager-1      | 2024-03-11 06:25:06.687192 [INFO] iso15118_charge  :: Module iso15118_charger initialized [6407ms]
everest-demo-mqtt-server-1  | 1710138306: New connection from 172.21.0.3:36684 on port 1883.
everest-demo-mqtt-server-1  | 1710138306: New client connected from 172.21.0.3:36684 as auto-EFA0EFF9-4BA9-200E-1232-78BF1A74B1DE (p2, c1, k400).
everest-demo-mqtt-server-1  | 1710138307: New connection from 172.21.0.3:36686 on port 1883.
everest-demo-mqtt-server-1  | 1710138307: New client connected from 172.21.0.3:36686 as auto-CB8B94D9-C0AC-0408-605D-8DBBCB68F36B (p2, c1, k400).
```

We should test better on Linux, but for now, let's keep OSX working