### PR TITLE
Updated OCPP 2.0.1 Security Profile 2 MRE demo script

### DIFF
--- a/docker-compose.ocpp201.sp2.yml
+++ b/docker-compose.ocpp201.sp2.yml
@@ -23,6 +23,8 @@ services:
     entrypoint: "tail -f /dev/null"
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   nodered:
     image: ghcr.io/everest/everest-demo/nodered:${TAG}


### PR DESCRIPTION
Adjusted creation of OCPP server (MaEVe CSMS) certificate bundles based on conversations in Zulip around the topic.

Added `extra_hosts` config to EVerest Manager service in relevant Docker Compose file to get constent behavior on all platforms for the `host.docker.internal` DNS name that is used as part of the demo.

See #25 for additional details.

Note that in order to test this, you will need to temporarily adjust line 34 of the `demo-iso15118-2-ac-plus-ocpp201.sp2.sh` script to use the head repo and branch for this PR. For example, `git clone --branch ocpp-demo-mre https://github.com/activeshadow/everest-demo.git`.

Also note that I've been having on-and-off luck with the Envoy load balancer that's used by default in the MaEVe CSMS project. For testing, you can use a version of MaEVe with the load balancer disabled by adjusting line 37 to use the `no-lb` branch of my fork of MaEVE.