### PR TITLE
🦈⚡ Add Edgeshark and Eonti MRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ in your terminal before one of the one-liners presented in the next section.
 ### OPTIONAL: Explore a demo with Edgeshark
 - For each demo of ISO 15118-2 AC Charging with OCPP, the demo may be ran alongside [Edgeshark](httpos://github.com/siemans/edgeshark?tab=readme-ov-file#edgeshark) for additional information on the network connection between each container.
 - To launch a Edgeshark alongside one of these demos, include the -s flag when running the demo 
-  - 🦈 Example Profile 2 ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s - -s - -2`
+  - 🦈 Example Profile 2 ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -s -2`
 - Using your preferred web browser, navigate to http://localhost:5001 and explore the connections via the discovery engine.
   - If you have installed the [cshargextcap plugin](https://github.com/siemens/cshargextcap?tab=readme-ov-file#containershark-extcap-plugin-for-wireshark), you may launch [Wireshark Desktop](https://www.wireshark.org/download.html) from the discovery engine, to perform a live capture.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ in your terminal before one of the one-liners presented in the next section.
 - Run the demo: 💄 exploring configs 🔧: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.admin-panel.yml && docker compose -p everest-admin-panel up`
 - Access the visual representation at http://localhost:8849
 
+### OPTIONAL: Explore a demo with Edgeshark
+- For each demo of ISO 15118-2 AC Charging with OCPP, the demo may be ran alongside [Edgeshark](httpos://github.com/siemans/edgeshark?tab=readme-ov-file#edgeshark) for additional information on the network connection between each container.
+- To launch a Edgeshark alongside one of these demos, include the -s flag when running the demo 
+  - 🦈 Example Profile 2 ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s - -s - -2`
+- Using your preferred web browser, navigate to http://localhost:5001 and explore the connections via the discovery engine.
+  - If you have installed the [cshargextcap plugin](https://github.com/siemens/cshargextcap?tab=readme-ov-file#containershark-extcap-plugin-for-wireshark), you may launch [Wireshark Desktop](https://www.wireshark.org/download.html) from the discovery engine, to perform a live capture.
+
 ### TEARDOWN: Clean up after the demo
 - Kill the demo process
 - Delete files and containers: `docker compose -p [prefix] down && rm docker-compose.yml`

--- a/demo-iso15118-2-ac-plus-ocpp.sh
+++ b/demo-iso15118-2-ac-plus-ocpp.sh
@@ -10,7 +10,7 @@ CSMS="maeve"
 
 
 
-usage="usage: $(basename "$0") [-r <repo>] [-b <branch>] [-c <csms>] [-j|1|2|3] [-h]
+usage="usage: $(basename "$0") [-r <repo>] [-b <branch>] [-c <csms>] [-s] [-j|1|2|3] [-h]
 
 This script will run EVerest ISO 15118-2 AC charging with OCPP demos.
 
@@ -21,6 +21,7 @@ where:
     -r   URL to everest-demo repo to use (default: $DEMO_REPO)
     -b   Branch of everest-demo repo to use (default: $DEMO_BRANCH)
     -c   Use CitrineOS CSMS (default: MaEVe)
+    -s   Run with Edgeshark
     -j   OCPP v1.6j
     -1   OCPP v2.0.1 Security Profile 1
     -2   OCPP v2.0.1 Security Profile 2
@@ -30,16 +31,17 @@ where:
 
 DEMO_VERSION=
 DEMO_COMPOSE_FILE_NAME=
-
+RUN_WITH_EDGESHARK=false
 
 # loop through positional options/arguments
-while getopts ':r:b:cj123h' option; do
+while getopts ':r:b:c:sj123h' option; do
   case "$option" in
     r)  DEMO_REPO="$OPTARG" ;;
     b)  DEMO_BRANCH="$OPTARG" ;;
     c)  CSMS="citrine"
         CSMS_REPO="https://github.com/citrineos/citrineos-core" 
         CSMS_BRANCH="63670f3adc09266a0977862d972b0f7e440c577f" ;;
+    s)  RUN_WITH_EDGESHARK=true ;;
     j)  DEMO_VERSION="v1.6j"
         DEMO_COMPOSE_FILE_NAME="docker-compose.ocpp16j.yml" ;;
     1)  DEMO_VERSION="v2.0.1-sp1"
@@ -84,12 +86,19 @@ echo "DEMO VERSION: $DEMO_VERSION"
 echo "DEMO CONFIG:  $DEMO_COMPOSE_FILE_NAME"
 echo "DEMO DIR:     $DEMO_DIR"
 
-
 cd "${DEMO_DIR}" || exit 1
 
 
 echo "Cloning EVerest from ${DEMO_REPO} into ${DEMO_DIR}/everest-demo"
 git clone --branch "${DEMO_BRANCH}" "${DEMO_REPO}" everest-demo
+
+echo "Run with Edgeshark? $RUN_WITH_EDGESHARK"
+
+if [[ "$RUN_WITH_EDGESHARK" = true ]]; then
+  wget -q --no-cache -O - \
+  https://github.com/siemens/edgeshark/raw/main/deployments/wget/docker-compose-localhost.yaml \
+  | docker compose -f - up -d
+fi
 
 if [[ "$DEMO_VERSION" != v1.6j ]]; then
   echo "Cloning ${CSMS} CSMS from ${CSMS_REPO} into ${DEMO_DIR}/${CSMS}-csms and starting it"


### PR DESCRIPTION
This PR intends to accomplish the following:

- [x] Add the ability Edgeshark as a flag in ISO-15118-2 AC Charging With OCPP demos, so that developers may monitor the network connections between containers
- [ ] Fix the Eonti Certificate issues details in Issue #37, 
  - [ ] Once the certs are working, add an additional MRE to `demo-iso15118-2-ac-plus-ocpp.sh`