### PR TITLE
Changes from previous PR on Running automated tests via CICD

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -105,9 +105,11 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image_name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}
 
-      # Following fours steps are specifically for running automated steps which includes loading the 
+      # Following four steps are specifically for running automated tests which includes loading the 
       # mqtt-server image from the GitHub Actions Cache so that the docker compose automated tests can 
       # use this already built image instead of pulling it from GitHub Container Registry
+      # Note: These steps are only for the mqtt-server and the manager images and not for the nodered image.
+      # This is because, currently, docker-compose.automated-tests.yml uses only these two images for running automated tests.
       - name: Save Docker image
         if: ${{ matrix.image_name == 'mqtt-server' }}
         id: save-mqtt-image
@@ -143,7 +145,7 @@ jobs:
         run: |
           docker images
           echo "Running docker compose up..."
-          docker compose --project-name everest-ac-demo \
+          docker compose --project-name everest-ac-automated-testing \
                   --file "docker-compose.automated-tests.yml" up \
                     --abort-on-container-exit \
                     --exit-code-from manager

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -94,8 +94,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          context: ${{ matrix.context }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image_name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}
+    
+      - name: Run automated tests using docker-compose.automated-tests.yml
+        if: ${{ matrix.image_name == 'manager' }}
+        run: |
+          echo "Running docker compose up..."
+          docker compose --project-name everest-ac-demo \
+                  --file "docker-compose.automated-tests.yml" up \
+                    --abort-on-container-exit \
+                    --exit-code-from manager
+
+          exit_code=$?            
+          echo "Docker-compose up exit code from manager service: $exit_code"
+      
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -22,14 +22,14 @@ jobs:
       matrix:
         include:
           - host_namespace: ghcr.io/everest/everest-demo
-            image_name: manager
-            context: ./manager
-          - host_namespace: ghcr.io/everest/everest-demo
             image_name: mqtt-server
             context: ./mosquitto
           - host_namespace: ghcr.io/everest/everest-demo
             image_name: nodered
             context: ./nodered
+          - host_namespace: ghcr.io/everest/everest-demo
+            image_name: manager
+            context: ./manager
 
     steps:
       - name: Checkout
@@ -93,7 +93,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+    
       - name: Build and export to Docker
         uses: docker/build-push-action@v6
         with:
@@ -104,10 +104,44 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image_name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image_name }}
+
+      # Following fours steps are specifically for running automated steps which includes loading the 
+      # mqtt-server image from the GitHub Actions Cache so that the docker compose automated tests can 
+      # use this already built image instead of pulling it from GitHub Container Registry
+      - name: Save Docker image
+        if: ${{ matrix.image_name == 'mqtt-server' }}
+        id: save-mqtt-image
+        shell: bash
+        run: |
+          echo "TAG=${{ steps.docker-image-version-check.outputs.TAG }}"
+          docker save --output /tmp/mqtt-server_${{ steps.docker-image-version-check.outputs.TAG }}.tar ghcr.io/everest/everest-demo/mqtt-server:${{ steps.docker-image-version-check.outputs.TAG }}
+      
+      - name: Upload mqtt-server image as Artifact
+        if: ${{ matrix.image_name == 'mqtt-server' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mqtt_server_image_${{ steps.docker-image-version-check.outputs.TAG }}
+          path: /tmp/mqtt-server_${{ steps.docker-image-version-check.outputs.TAG }}.tar
+          overwrite: true
+
+      - name: Download mqtt-server image as Artifact
+        if: ${{ matrix.image_name == 'manager' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: mqtt_server_image_${{ steps.docker-image-version-check.outputs.TAG }}
+          path: /tmp
+
+      - name: Load Docker image
+        if: ${{ matrix.image_name == 'manager' }}
+        id: load-mqtt-image
+        shell: bash
+        run: |
+          docker load --input /tmp/mqtt-server_${{ steps.docker-image-version-check.outputs.TAG }}.tar     
     
       - name: Run automated tests using docker-compose.automated-tests.yml
         if: ${{ matrix.image_name == 'manager' }}
         run: |
+          docker images
           echo "Running docker compose up..."
           docker compose --project-name everest-ac-demo \
                   --file "docker-compose.automated-tests.yml" up \

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 ghcr.io/everest/build-kit-alpine:latest
+FROM --platform=linux/x86_64 ghcr.io/everest/build-kit-alpine@sha256:7494bd6624aee3f882b4f1edbc589879e1d6d0ccc2c58f3f5c87ac1838ccd1de
 
 ARG EVEREST_VERSION=2024.3.0
 ENV EVEREST_VERSION=${EVEREST_VERSION}


### PR DESCRIPTION
The previous PR #62 commit history got messed up due to rebasing to handle the commits that had missing signoffs. Created a new PR to bring over the final changes from there.

The goal was to have automated tests run as a part of the CI/CD pipeline with GitHub Actions.

The commit history and detailed discussion can be seen in the previous PR #62 