### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is a table of demonstrations that are currently available.
    - No additional steps needed, move to [Install and Set-up](Install-and-Set-up)
 - Windows
    - Ensure that you are running Windows 10+
-   - Install [Windows Subsystem for Linux](https://usg02.safelinks.protection.office365.us/?url=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fwindows%2Fwsl%2Finstall&data=05%7C02%7Cnathan.serway%40afs.com%7Cbb027205f7784cbdcff508dcd76a1fa9%7Ca01f407a85cb4a1698bbf28e6384bd28%7C0%7C0%7C638622099325443284%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=aV05w32C%2B6EHcwN9NJKRa8ZxoioXdPsrMhewE%2Bjvaps%3D&reserved=0) (recommended version 2.0)
+   - Install [Windows Subsystem for Linux](https:://learn.microsoft.com/en-us/windows/wsl/install) (recommended version 2.0)
    - Move to [Install and Set-up](Install-and-Set-up)
 
 # Install and Set-up

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ move to Step 4: Teardown before attempting to start new demo.
 
 |Features| Description |
 | -- | ---- |
-|<img src="img/One_EV_EVSE_UI.png" alt="Demo UI" width="249" height="572">| |
+|<img src="img/One_EV_EVSE_UI.png" alt="Demo UI" width="249" height="572"/>| |
 | `CAR PLUGIN` | Starts the charging cycle |
 | `STOP & UNPLUG` | Stops the charging cycle |
 | `EV PAUSE` | Pause the charging session |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Copy and paste the command for the demo you wish to run into the Docker terminal
    - **Two EV ↔ EVSE:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-two-evse.sh | bash`
    - **E2E Automated Tests:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-automated-testing.sh | bash`
    - OCPP Demos:
-      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 1.6J CSMS (StEVe):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -j`
       - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -1` 
       - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 2):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -2`
       - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 3):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -3`
@@ -99,7 +98,7 @@ There are many different variables that the user can experiment with throughout 
 
 ### One EV ↔ EVSE (ISO 15118 AC) Demo
 
-- When running the Basic and ISO 15118-2 AC Charging with OCPP 1.6J CSMS demo, you can open the SteVe wep portal at http://localhost:8180/steve/manager/home. Login with username: admin, password: 1234
+- You can open the SteVe wep portal at http://localhost:8180/steve/manager/home. Login with username: admin, password: 1234 when running the OCPP Demos
 - When running the Basic and ISO 15118-2 AC Charging with OCPP 201 CSMS demo, the script currently checks out the maeve repository and builds it, so it is fairly slow.
   - It starts the Maeve containers in detached mode, so you would need to use docker desktop or `docker logs` to see the logs
   - Note that the OCPP logs are available at `/tmp/everest_ocpp_logs/` on the EVerest manager and can be downloaded using the docker desktop or `docker cp`

--- a/README.md
+++ b/README.md
@@ -117,6 +117,24 @@ export EVEREST_MANAGER_CPUS='2.0' EVEREST_MANAGER_MEMORY='1536mb'
   
 - Access the visual representation at http://localhost:8849
 
+# Contributing to The Demonstration Repository
+
+First, thank you for your interest in contributing to the demo repository. Please
+ follow the steps outlined below to not only contribute your demonstration,
+but update the documentation associated with the Demo:
+
+1. Submit a Pull Request with a functional `curl` script based demonstration to
+the EVerest Demo Repository
+2. Add the following content to the "Hosted Demos" section:
+    1. Demo Column, add the demo's name
+    2. Content Column, add a one sentence description of function of the demo
+    3. Diagram Column, create a high-level [mermaid diagram](https://mermaid.js.org/intro/getting-started.html) of the demo functionality and add the diagram to the
+    "Appendix Diagrams" section with a
+    hyperlink to the section in the column
+3. Add the `curl` script to the "Demo Commands" list
+4. If there is any additional functionality not covered in the current documentation
+please add the details to the "Additional Functionality" section
+
 # Appendix Diagrams
 
 The following diagrams provide a visual representation of the above demos.

--- a/README.md
+++ b/README.md
@@ -1,82 +1,100 @@
-# Vision 
+# EVerest Demo Repo
 
-This repository includes several demos of the [EVerest](https://lfenergy.org/projects/everest/) tech stack's capabilities. The intent of this repository is to showcase the foundational layers of a charging solution that could address interoperability and reliability issues in the EV charging industry. The demonstrations aim to exemplify the modular nature of EVerest and can be utilized to understand the following: 
+## Vision
 
-- Standards-based implementations for driving interoperability between the EV, EVSE, and CSMS
+This repository includes several demos of the [EVerest](https://lfenergy.org/projects/everest/)
+tech stack's capabilities. The intent of this repository is to showcase the
+foundational layers of a charging solution that could address interoperability
+and reliability issues in the EV charging industry. The demonstrations aim to
+exemplify the modular nature of EVerest and can be utilized to understand the
+following:
+
+- Standards-based implementations for driving interoperability between the EV,
+EVSE, and CSMS
 - Interoperability testing tools and test suites
-- Simulated EVs, EVSEs, etc. following interoperability best practices and simulating stress testing scenarios 
+- Simulated EVs, EVSEs, etc. following interoperability best practices and
+simulating stress testing scenarios
 
-# Hosted Demos
+## Hosted Demos
 
 Below is a table of demonstrations that are currently available.
 
 | Demo | Content | Diagram |
 | ---- | -- | :---: |
-| **One EV ↔ EVSE (AC Simulation)** | Simple AC charging session with one EV connecting to one Charger (EVSE) | [One EV ↔ EVSE (AC Simulation) Diagram](#One-EV-to-EVSE-(AC-Simulation)) |
-| **One EV ↔ EVSE (ISO 15118-2 DC)** | ISO 15118-2 compliant charging session with one EV connecting to one EVSE | [One EV ↔ EVSE (ISO 15118-2 DC) Diagram](#One-EV-to-EVSE-(ISO-15118-2-DC))|
-| **Two EV ↔ EVSE** | Two EVSE connector points showcasing EVerests ability to work with a CSMS in a multi-station context | [Two EV ↔ EVSE Diagram](#Two-EV-to-EVSE) |
+| **One EV ↔ EVSE (AC Simulation)** | Simple AC charging session with one EV connecting to one Charger (EVSE) | [One EV ↔ EVSE (AC Simulation) Diagram](#one-ev-to-evse-ac-simulation) |
+| **One EV ↔ EVSE (ISO 15118-2 DC)** | ISO 15118-2 compliant charging session with one EV connecting to one EVSE | [One EV ↔ EVSE (ISO 15118-2 DC) Diagram](#one-ev-to-evse-iso-15118-2-dc)|
+| **Two EV ↔ EVSE** | Two EVSE connector points showcasing EVerests ability to work with a CSMS in a multi-station context | [Two EV ↔ EVSE Diagram](#two-ev-to-evse) |
 | **E2E Automated Tests** | Performs an automated test of a full charging session| N/A |
-| **OCPP Demos** | Various OCPP 1.6J and 2.0.1 compliant charging sessions with differing security profiles| [OCPP Demo Diagram](#OCPP-Demos)|
+| **OCPP Demos** | Various OCPP 1.6J and 2.0.1 compliant charging sessions with differing security profiles| [OCPP Demo Diagram](#ocpp-demos)|
 
-# Operating System Specific Instructions 
+## Operating System Specific Instructions
 
 - Mac OS
-   - EVerest Demos are currently NOT supported on M1 chips
+  - EVerest Demos are currently NOT supported on M1 chips
 - Linux
-   - No additional steps needed, move to [Install and Set-up](Install-and-Set-up)
+  - No additional steps needed, move to [Install and Set-up](Install-and-Set-up)
 - Windows
-   - Ensure that you are running Windows 10+
-   - Install [Windows Subsystem for Linux](https:://learn.microsoft.com/en-us/windows/wsl/install) (recommended version 2.0)
-   - Move to [Install and Set-up](Install-and-Set-up)
+  - Ensure that you are running Windows 10+
+  - Install [Windows Subsystem for Linux](https:://learn.microsoft.com/en-us/windows/wsl/install)
+  (recommended version 2.0)
+  - Move to [Install and Set-up](Install-and-Set-up)
 
-# Install and Set-up
+## Install and Set-up
 
 1. Install docker with the following link [Get Docker](https://docs.docker.com/get-docker/)
 
-2. Ensure that docker is installed by opening your machines terminal and typing `docker --version`
+2. Ensure that docker is installed by opening your machines terminal and typing
+`docker --version`
 
    - Note: The terminal should return "Docker version x.x.x".
 
 3. Open the Docker desktop application
-   
+
 4. Open your machines terminal
 
-# Step 1: Select the Demo
+## Run the Demonstration
+
+### Step 1: Select the Demo
 
 Copy and paste the command for the demo you wish to run into the machines terminal.
 
-   - Note: After you enter the command into the terminal, the docker application should open the associated containers
+- Note: After you enter the command into the terminal, the docker application
+should open the associated containers
 
-### Demo Commands 
+#### Demo Commands
 
-   - **One EV ↔ EVSE (AC Simulation):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-ac.sh | bash`
-   - **One EV ↔ EVSE (ISO 15118 AC):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-dc.sh | bash`
-   - **Two EV ↔ EVSE:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-two-evse.sh | bash`
-   - **E2E Automated Tests:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-automated-testing.sh | bash`
-   - OCPP Demos:
-      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -1` 
-      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 2):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -2`
-      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 3):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -3`
-      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (CitrineOS Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -c -1`
+- **One EV ↔ EVSE (AC Simulation):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-ac.sh | bash`
+- **One EV ↔ EVSE (ISO 15118 AC):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-dc.sh | bash`
+- **Two EV ↔ EVSE:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-two-evse.sh | bash`
+- **E2E Automated Tests:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-automated-testing.sh | bash`
+- OCPP Demos:
+  - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -1`
+  - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 2):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -2`
+  - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 3):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -3`
+  - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (CitrineOS Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -c -1`
 
-# Step 2: Open Demo Interface and Supporting Materials 
+### Step 2: Open Demo Interface and Supporting Materials
 
-1. Open the demo UI at http://127.0.0.1:1880/ui
+1. Open the demo UI at <http://127.0.0.1:1880/ui>
 
-   - Note: The demo UI will vary based on the demonstration that is selected. For the best results, having the demo UI and Docker desktop application up side-by-side will allow the user to understand what messages are being sent back-and-fourth across the demo actors. 
-     
-2. Open the `nodered` flows to understand the module flows at http://127.0.0.1:1880
+   - Note: The demo UI will vary based on the demonstration that is selected.
+   For the best results, having the demo UI and Docker desktop application up
+   side-by-side will allow the user to understand what messages are being sent
+   back-and-fourth across the demo actors.
 
-   - Note: The nodered flows will allow the user to understand how modules interact within the demonstrations. For  more information on simulating Everest with software, the simulation GUI, and NODE RED, click [here](https://everest.github.io/nightly/general/03_quick_start_guide.html#simulating-everest)
- 
- 
-# Step 3: Interact with the Demo
+2. Open the `nodered` flows to understand the module flows at <http://127.0.0.1:1880>
 
-Feel free to explore these demos on your own accord. Below is a table that will help the user understand how to interact with the UI.
+   - Note: The nodered flows will allow the user to understand how modules
+   interact within the demonstrations. For  more information on simulating
+   Everest with software, the simulation GUI, and NODE RED, click [here](https://everest.github.io/nightly/general/03_quick_start_guide.html#simulating-everest)
 
-Note: Only one demonstration can be run at a time, in order to spin up a new demo, move to Step 4: Teardown before attempting to start new demo.
+### Step 3: Interact with the Demo
 
- 
+Feel free to explore these demos on your own accord. Below is a table that will
+help the user understand how to interact with the UI.
+
+Note: Only one demonstration can be run at a time, in order to spin up a new demo,
+move to Step 4: Teardown before attempting to start new demo.
 
 |Features| Description |
 | -- | ---- |
@@ -88,38 +106,52 @@ Note: Only one demonstration can be run at a time, in order to spin up a new dem
 | `Car Simulation` dropdown | Changes the charging scenario (i.e., chaos testing) |
 | `Max Current` slider | Slide to adjust the current provided to the vehicle |
 
-   
-# Step 4: Teardown
+### Step 4: Teardown
 
 - Select all Docker containers
-- Delete all files and containers: `docker compose -p [prefix] down && rm docker-compose.yml` where `[prefix]` is `everest, everest-dc, everest-two-evse...`
+- Delete all files and containers: `docker compose -p [prefix] down && rm docker-compose.yml`
+where `[prefix]` is `everest, everest-dc, everest-two-evse...`
 
-# Additional Functionality  
+## Additional Functionality  
 
-There are many different variables that the user can experiment with throughout the demonstrations. See below:
+There are many different variables that the user can experiment with throughout
+the demonstrations. See below:
 
 ### One EV ↔ EVSE (ISO 15118 AC) Demo
 
-- You can open the SteVe wep portal at http://localhost:8180/steve/manager/home. Login with username: admin, password: 1234 when running the OCPP Demos
-- When running the Basic and ISO 15118-2 AC Charging with OCPP 201 CSMS demo, the script currently checks out the maeve repository and builds it, so it is fairly slow.
-  - It starts the Maeve containers in detached mode, so you would need to use docker desktop or `docker logs` to see the logs
-  - Note that the OCPP logs are available at `/tmp/everest_ocpp_logs/` on the EVerest manager and can be downloaded using the docker desktop or `docker cp`
+- You can open the SteVe wep portal at <http://localhost:8180/steve/manager/home>.
+Login with username: admin, password: 1234 when running the OCPP Demos
+- When running the Basic and ISO 15118-2 AC Charging with OCPP 201 CSMS demo,
+the script currently checks out the maeve repository and builds it, so it is
+fairly slow.
+  - It starts the Maeve containers in detached mode, so you would need to use
+  docker desktop or `docker logs` to see the logs
+  - Note that the OCPP logs are available at `/tmp/everest_ocpp_logs/` on the
+  EVerest manager and can be downloaded using the docker desktop or `docker cp`
 
 ### All Demos
 
-- You can experiment with different constraints for a demo by exporting `EVEREST_MANAGER_CPUS` and `EVEREST_MANAGER_MEMORY` environment variables prior to running one of the demos. The values of these variables can take on any valid Docker [CPU value](https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler) and [memory limit](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory), respectively. For example, to run a demo with two CPUs and 1536 MB of RAM, you could execute
+- You can experiment with different constraints for a demo by exporting `EVEREST_MANAGER_CPUS`
+and `EVEREST_MANAGER_MEMORY` environment variables prior to running one of the demos.
+The values of these variables can take on any valid Docker
+[CPU value](https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler)
+and [memory limit](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory),
+respectively. For example, to run a demo with two CPUs and 1536 MB of RAM, you
+could execute
 
 ```bash
 export EVEREST_MANAGER_CPUS='2.0' EVEREST_MANAGER_MEMORY='1536mb'
 ```
 
-- This demo can be run independently, and exports [the admin panel](https://everest.github.io/nightly/general/03_quick_start_guide.html#admin-panel-and-simulations) as explained [in this video](https://youtu.be/OJ6kjHRPkyY?t=904).It provides a visual representation of the configuration and the resulting configurations.
+- This demo can be run independently, and exports [the admin panel](https://everest.github.io/nightly/general/03_quick_start_guide.html#admin-panel-and-simulations)
+as explained [in this video](https://youtu.be/OJ6kjHRPkyY?t=904).It provides a
+visual representation of the configuration and the resulting configurations.
   
 - Run the explore configs demo: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.admin-panel.yml && docker compose -p everest-admin-panel up`
   
-- Access the visual representation at http://localhost:8849
+- Access the visual representation at <http://localhost:8849>
 
-# Contributing to The Demonstration Repository
+## Contributing to The Demonstration Repository
 
 First, thank you for your interest in contributing to the demo repository. Please
  follow the steps outlined below to not only contribute your demonstration,
@@ -130,24 +162,24 @@ the EVerest Demo Repository
 2. Add the following content to the "Hosted Demos" section:
     1. Demo Column, add the demo's name
     2. Content Column, add a one sentence description of function of the demo
-    3. Diagram Column, create a high-level [mermaid diagram](https://mermaid.js.org/intro/getting-started.html) of the demo functionality and add the diagram to the
+    3. Diagram Column, create a high-level [mermaid diagram](https://mermaid.js.org/intro/getting-started.html)
+    of the demo functionality and add the diagram to the
     "Appendix Diagrams" section with a
     hyperlink to the section in the column
 3. Add the `curl` script to the "Demo Commands" list
 4. If there is any additional functionality not covered in the current documentation
 please add the details to the "Additional Functionality" section
 
-# Reference Material
+## Reference Material
 
 - [ISO 15118-2 Documentation](https://www.typhoon-hil.com/documentation/typhoon-hil-software-manual/References/iso15118_protocol.html)
 - [OCPP 2.0.1 Documentation](https://openchargealliance.org/my-oca/ocpp/)
   
-
-# Appendix Diagrams
+## Appendix Diagrams
 
 The following diagrams provide a visual representation of the above demos.
 
-### One EV to EVSE (AC Simulation)
+### One EV to EVSE AC Simulation
 
  ```mermaid
 
@@ -166,9 +198,9 @@ sequenceDiagram
     EV->>EVSE: Unplug (State A)
     Note over EVSE, EV: Session Ends
  
-``` 
+```
 
-### One EV to EVSE (ISO 15118 2 DC)
+### One EV to EVSE ISO 15118 2 DC
 
 ```mermaid
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository includes several demos of the [EVerest](https://lfenergy.org/pro
 
 # Hosted Demos
 
-Below is a table of demonstrations that are currently avaialble.
+Below is a table of demonstrations that are currently available.
 
 | Demo | Content | Diagram |
 | ---- | -- | :---: |
@@ -21,7 +21,7 @@ Below is a table of demonstrations that are currently avaialble.
 # Operating System Specific Instructions 
 
 - Mac OS
-   - EVerest Demos are curently NOT supported on M1 chips
+   - EVerest Demos are currently NOT supported on M1 chips
 - Linux
    - No additional steps needed, move to [Install and Set-up](Install-and-Set-up)
 - Windows
@@ -33,7 +33,7 @@ Below is a table of demonstrations that are currently avaialble.
 
 1. Install docker with the following link [Get Docker](https://docs.docker.com/get-docker/)
 
-   - Note: When runing the demonstrations, use the Docker desktop terminal for the best results. However, demonstration commands can be posted directly into your machine's terminal if running on Windows or Linux systems.
+   - Note: When running the demonstrations, use the Docker desktop terminal for the best results. However, demonstration commands can be posted directly into your machine's terminal if running on Windows or Linux systems.
 
 2. Ensure that docker is installed by opening your machines terminal and typing `docker --version`
 
@@ -64,7 +64,7 @@ Copy and paste the command for the demo you wish to run into the Docker terminal
 
 1. Open the demo UI at http://127.0.0.1:1880/ui
 
-   - Note: The demo UI will vary based on the demonstration that is selected. For the best results, having the demo UI and Docker desktop applciation up side-by-side will allow the user to understand what messages are being sent back-and-fourth across the demo actors. 
+   - Note: The demo UI will vary based on the demonstration that is selected. For the best results, having the demo UI and Docker desktop application up side-by-side will allow the user to understand what messages are being sent back-and-fourth across the demo actors. 
      
 2. Open the `nodered` flows to understand the module flows at http://127.0.0.1:1880
 
@@ -97,7 +97,7 @@ Note: Only one demonstration can be run at a time, in order to spin up a new dem
 
 # Additional Functionality  
 
-There are many different variables that the user can experiment with thorughout the demonstrations. See below:
+There are many different variables that the user can experiment with throughout the demonstrations. See below:
 
 ### One EV ↔ EVSE (ISO 15118 AC) Demo
 

--- a/README.md
+++ b/README.md
@@ -1,112 +1,277 @@
-# Quick EVerest Demos
+# Vision 
 
-This repository is a repackaging of several simple demos of the EVerest tech stack. Our intent is to showcase the foundational layers of a charging solution that could address interoperability and reliability issues in the industry. EVerest is currently in the _early adoption_ stage of the [LF Energy Technical Project Lifecycle](https://wiki.lfenergy.org/display/HOME/Technical+Project+Lifecycle).
+This repository includes several demos of the [EVerest](https://lfenergy.org/projects/everest/) tech stack's capabilities. The intent of this repository is to showcase the foundational layers of a charging solution that could address interoperability and reliability issues in the EV charging industry. The demonstrations aim to exemplify the modular nature of EVerest and can be utilized to understand the following: 
 
-## What is EVerest?
-[EVerest](https://lfenergy.org/projects/everest/) is a [Linux Foundation Energy](https://lfenergy.org/) project aiming to provide a modular, open-source framework and tech stack for all manner of electric vehicle chargers. This mission and architecture mean EVerest is well positioned to serve as the base for a reference implementation of a variety of standards that can drive interoperability in the eMobility space.
+- Standards-based implementations for driving interoperability between the EV, EVSE, and CSMS
+- Interoperability testing tools and test suites
+- Simulated EVs, EVSEs, etc. following interoperability best practices and simulating stress testing scenarios 
 
-### Vision
-The [US Joint Office of Energy and Transportation (US-JOET)](https://driveelectric.gov/) plans to use EVerest as a baseline from which to collaboratively build reliable interoperability solutions for EV charging, including:
-- reference implementations for standards driving interoperability between network actors including EVs, EVSEs, and CSMSs
-- interoperability testing tools and test suites
-- simulated EVs, EVSEs, etc. following interoperability best practices.
+# Hosted Demos
 
-The US-JOET has contributed this repository to the base everest project and continue modifying it to explore additional configurations.
+Below is a table of demonstrations that are currently avaialble.
 
-### EVerest currently supports the following standards
-- EN 61851
-- ISO 15118 (AC wired charging)
-    - SLAC / ISO 15118-3 in C++
-    - ISO 15118-2 AC
-- DC DIN SPEC 70121
-- OCPP 1.6J including profiles and security extensions
-- Partial OCPP 2.0.1 implementation
-    
-### Roadmap Items in Development
-- Full OCPP 2.0.1 / 2.1
-- ISO 15118-20
-- Robust error handling/reporting
+| Demo | Content | Diagram |
+| ---- | -- | :---: |
+| **One EV ↔ EVSE (AC Simulation)** | Simple AC charging session with one EV connecting to one Charger (EVSE) | [One EV ↔ EVSE (AC Simulation) Diagram](#One-EV-to-EVSE-(AC-Simulation)) |
+| **One EV ↔ EVSE (ISO 15118-2 DC)** | ISO 15118-2 compliant charging session with one EV connecting to one EVSE | [One EV ↔ EVSE (ISO 15118-2 DC) Diagram](#One-EV-to-EVSE-(ISO-15118-2-DC))|
+| **Two EV ↔ EVSE** | Two EVSE connector points showcasing EVerests ability to work with a CSMS in a multi-station context | [Two EV ↔ EVSE Diagram](#Two-EV-to-EVSE) |
+| **E2E Automated Tests** | Performs an automated test of a full charging session| N/A |
+| **OCPP Demos** | Various OCPP 1.6J and 2.0.1 compliant charging sessions with differing security profiles| [OCPP Demo Diagram](#OCPP-Demos)|
 
-## SETUP: access docker
+# Operating System Specific Instructions 
 
-- If you are a developer, you might already have docker installed on your laptop. If not, [Get Docker](https://docs.docker.com/get-docker/)
-    - Check that the terminal has access to `docker` and `docker compose`
+- Mac OS
+   - EVerest Demos are curently NOT supported on M1 chips
+- Linux
+   - No additional steps needed, move to [Install and Set-up](Install-and-Set-up)
+- Windows
+   - Ensure that you are running Windows 10+
+   - Install [Windows Subsystem for Linux](https://usg02.safelinks.protection.office365.us/?url=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fwindows%2Fwsl%2Finstall&data=05%7C02%7Cnathan.serway%40afs.com%7Cbb027205f7784cbdcff508dcd76a1fa9%7Ca01f407a85cb4a1698bbf28e6384bd28%7C0%7C0%7C638622099325443284%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=aV05w32C%2B6EHcwN9NJKRa8ZxoioXdPsrMhewE%2Bjvaps%3D&reserved=0) (recommended version 2.0)
+   - Move to [Install and Set-up](Install-and-Set-up)
+
+# Install and Set-up
+
+1. Install docker with the following link [Get Docker](https://docs.docker.com/get-docker/)
+
+   - Note: When runing the demonstrations, use the Docker desktop terminal for the best results. However, demonstration commands can be posted directly into your machine's terminal if running on Windows or Linux systems.
+
+2. Ensure that docker is installed by opening your machines terminal and typing `docker --version`
+
+   - Note: The terminal should return "Docker version x.x.x".
+
+3. Open the Docker desktop application and navigate to the terminal at the bottom of the screen. 
+
+# Step 1: Select the Demo
+
+Copy and paste the command for the demo you wish to run into the Docker terminal within the Docker desktop.
+
+   - Note: Each demonstration has a brief description in the "Content" column and high-level diagram in the "Diagram" column. 
+
+### Demo Commands 
+
+   - **One EV ↔ EVSE (AC Simulation):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-ac.sh | bash`
+   - **One EV ↔ EVSE (ISO 15118 AC):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-dc.sh | bash`
+   - **Two EV ↔ EVSE:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-two-evse.sh | bash`
+   - **E2E Automated Tests:** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-automated-testing.sh | bash`
+   - OCPP Demos:
+      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 1.6J CSMS (StEVe):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -j`
+      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -1` 
+      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 2):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -2`
+      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 3):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -3`
+      - **OCPP basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (CitrineOS Security Profile 1):** `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -c -1`
+
+# Step 2: Open Demo Interface and Supporting Materials 
+
+1. Open the demo UI at http://127.0.0.1:1880/ui
+
+   - Note: The demo UI will vary based on the demonstration that is selected. For the best results, having the demo UI and Docker desktop applciation up side-by-side will allow the user to understand what messages are being sent back-and-fourth across the demo actors. 
+     
+2. Open the `nodered` flows to understand the module flows at http://127.0.0.1:1880
+
+   - Note: The nodered flows will allow the user to understand how modules interact within the demonstrations. For  more information on simulating Everest with software, the simulation GUI, and NODE RED, click [here](https://everest.github.io/nightly/general/03_quick_start_guide.html#simulating-everest)
  
-## EV ↔ EVSE demos
+ 
+# Step 3: Interact with the Demo
 
-The demos in this repo showcase connectivity between one or two EVs and an EVSE.
-The protocol used by the EV can be selected using a UI dropdown. The dropdown can also be used to simulate errors on the EVCC.
-The use cases supported by the three demos are summarized in conceptual block diagrams below.
+Feel free to explore these demos on your own accord. Below is a table that will help the user understand how to interact with the UI.
 
-| Demo | Content |
-| ---- |:-------:|
-| **One EV ↔ EVSE (AC Simulations)** | <img src="img/one_ev_one_evse.png" width="400" height="246"> |
-| **One EV ↔ EVSE (ISO 15118-2 DC)** | <img src="img/one_ev_one_evse_iso15118-2_dc.png" width="400" height="246"> |
-| **Two EV ↔ EVSE** | <img src="img/two_ev_one_evse.png" width="400" height="246"> |
+Note: Only one demonstration can be run at a time, in order to spin up a new demo, move to Step 4: Teardown before attempting to start new demo.
 
-#### Demo Notes
-EVerest is designed with embedded applications in mind. To illustrate this, we've imposed maximum CPU usage and RAM constraints of 100% (1 core) and 1024MB, respectively, in each of the demos. The sole exception is the automated testing demo, where resource constraints are less relevant to the demo's purpose. Even on modest desktop hardware, these constraints should only result in slightly longer boot times.
+ 
 
-You can experiment with different constraints for a demo by exporting `EVEREST_MANAGER_CPUS` and `EVEREST_MANAGER_MEMORY` environment variables prior to running one of the demos. The values of these variables can take on any valid Docker [CPU value](https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler) and [memory limit](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory), respectively. For example, to run a demo with two CPUs and 1536 MB of RAM, you could execute
+|Features| Description |
+| -- | ---- |
+|<img src="img/One_EV_EVSE_UI.png" alt="Demo UI" width="249" height="572">| |
+| `CAR PLUGIN` | Starts the charging cycle |
+| `STOP & UNPLUG` | Stops the charging cycle |
+| `EV PAUSE` | Pause the charging session |
+| `EV RESUME` | Resume the charging cycle |
+| `Car Simulation` dropdown | Changes the charging scenario (i.e., chaos testing) |
+| `Max Current` slider | Slide to adjust the current provided to the vehicle |
 
-```bash
-export EVEREST_MANAGER_CPUS='2.0' EVEREST_MANAGER_MEMORY='1536mb'
-```
+   
+# Step 4: Teardown
 
-in your terminal before one of the one-liners presented in the next section.
+- Select all Docker containers
+- Delete all files and containers: `docker compose -p [prefix] down && rm docker-compose.yml` where `[prefix]` is `everest, everest-dc, everest-two-evse...`
 
+# Additional Functionality  
 
-### STEP 1: Run the demo
-- Copy and paste the command for the demo you want to see:
-    - 🚨 AC Charging ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-ac.sh | bash`
-    - 🚨 ISO 15118 DC Charging ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-dc.sh | bash`
-    - 🚨 Two EVSE Charging ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-two-evse.sh | bash`
-    - 🚨 E2E Automated Tests ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-automated-testing.sh | bash`
-    - 🚨 Basic and ISO 15118-2 AC Charging with OCPP 1.6J CSMS (StEVe) ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -j`
-    - 🚨 Basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 1) ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -1` 
-    - 🚨 Basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 2) ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -2`
-    - 🚨 Basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (MaEVe Security Profile 3) ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -3`
-    - 🚨 Basic and ISO 15118-2 AC Charging with OCPP 2.0.1 CSMS (CitrineOS Security Profile 1) ⚡: `curl https://raw.githubusercontent.com/everest/everest-demo/main/demo-iso15118-2-ac-plus-ocpp.sh | bash -s -- -c -1`
+There are many different variables that the user can experiment with thorughout the demonstrations. See below:
 
-> NOTE: the `Basic and ISO 15118-2 AC Charging with OCPP 1.6J CSMS (StEVe)` demo is known to fail intermittently, and will not be fixed.
+### One EV ↔ EVSE (ISO 15118 AC) Demo
 
-### STEP 2: Interact with the demo
-- Open the `nodered` flows to understand the module flows at http://127.0.0.1:1880
-- Open the demo UI at http://127.0.0.1:1880/ui
 - When running the Basic and ISO 15118-2 AC Charging with OCPP 1.6J CSMS demo, you can open the SteVe wep portal at http://localhost:8180/steve/manager/home. Login with username: admin, password: 1234
 - When running the Basic and ISO 15118-2 AC Charging with OCPP 201 CSMS demo, the script currently checks out the maeve repository and builds it, so it is fairly slow.
   - It starts the Maeve containers in detached mode, so you would need to use docker desktop or `docker logs` to see the logs
   - Note that the OCPP logs are available at `/tmp/everest_ocpp_logs/` on the EVerest manager and can be downloaded using the docker desktop or `docker cp`
 
-| Nodered flows | Demo UI | Including simulated error |
- |-------|--------|------|
- | ![nodered flows](img/node-red-example.png) | ![demo UI](img/charging-ui.png) | ![including simulated error](img/including-simulated-error.png) |
+### All Demos
 
- | SteVe web portal |
- |-------|
- | ![SteVe web portal](img/steve-web-portal.png) |
+- You can experiment with different constraints for a demo by exporting `EVEREST_MANAGER_CPUS` and `EVEREST_MANAGER_MEMORY` environment variables prior to running one of the demos. The values of these variables can take on any valid Docker [CPU value](https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler) and [memory limit](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory), respectively. For example, to run a demo with two CPUs and 1536 MB of RAM, you could execute
 
- | OCPP 201 with successful connection |
- |-------|
- | ![OCPP 201 connection](img/ocpp201-connection.png) |
- 
+```bash
+export EVEREST_MANAGER_CPUS='2.0' EVEREST_MANAGER_MEMORY='1536mb'
+```
 
-### STEP 3: See the list of modules loaded and the high level message exchange
-![Simple AC charging station log screenshot](img/simple_ac_charging_station.png)
-
-### OPTIONAL: Explore the configs visually
 - This demo can be run independently, and exports [the admin panel](https://everest.github.io/nightly/general/03_quick_start_guide.html#admin-panel-and-simulations) as explained [in this video](https://youtu.be/OJ6kjHRPkyY?t=904).It provides a visual representation of the configuration and the resulting configurations.
-- Run the demo: 💄 exploring configs 🔧: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.admin-panel.yml && docker compose -p everest-admin-panel up`
+  
+- Run the explore configs demo: `curl -o docker-compose.yml https://raw.githubusercontent.com/everest/everest-demo/main/docker-compose.admin-panel.yml && docker compose -p everest-admin-panel up`
+  
 - Access the visual representation at http://localhost:8849
 
-### TEARDOWN: Clean up after the demo
-- Kill the demo process
-- Delete files and containers: `docker compose -p [prefix] down && rm docker-compose.yml`
-where `[prefix]` is `everest, everest-dc, everest-two-evse...`
+# Appendix Diagrams
 
-## High level block diagram overview of EVerest capabilities
-From https://everest.github.io/nightly/general/01_framework.html
-![image](https://everest.github.io/nightly/_images/quick-start-high-level-1.png)
+The following diagrams provide a visual representation of the above demos.
 
-## Notes for Demo Contributors
-Docker images defined in this repository are built during pull requests, on merges to `main`, and on pushes of semantic version tags. The labels for newly-built images are determined by the `TAG` environment variable specified in the root level `.env` file in this repository. The value of `TAG` is also used throughout the demo `docker-compose.*.yml`.
+### One EV to EVSE (AC Simulation)
+
+ ```mermaid
+
+sequenceDiagram
+
+    participant EV as Electric Vehicle (EV)
+    participant EVSE as Electric Vehicle Supply Equipment (EVSE)
+    EV->>EVSE: Plug-in
+    EVSE-->>EV: Proximity Check (PP Signal)
+    EV->>EVSE: Detect Proximity
+    EVSE-->>EV: Control Pilot Signal
+    EV->>EVSE: Signal Response (State A to State B1)
+    EVSE-->>EV: Power Available?
+    EV-->>EVSE: Ready to Charge (State B2)
+    EVSE-->>EV: Start Charging (State B2 to State C2)
+    Note over EVSE, EV: Charging in progress
+    EV->>EVSE: Request Stop (State C2 to State B)
+    EVSE-->>EV: Power Cut Off
+    EVSE-->>EV: Control Pilot Signal (State B)
+    EV->>EVSE: Unplug (State A)
+    Note over EVSE, EV: Session Ends
+ 
+``` 
+
+### One EV to EVSE (ISO 15118 2 DC)
+
+```mermaid
+
+sequenceDiagram
+
+   participant EV as Electric Vehicle (EV)
+   participant EVSE as Electric Vehicle Supply Equipment (EVSE)
+   Note over EV,EVSE: Connection Establishment
+   EV ->> EVSE: Physical Connection (PLC)
+   EVSE ->> EV: SECC Discovery Response
+   Note over EV,EVSE: Session Setup
+   EV ->> EVSE: Session Setup Request
+   EVSE -->> EV: Session Setup Response
+   Note over EV,EVSE: Service Discovery
+   EV ->> EVSE: Service Discovery Request
+   EVSE -->> EV: Service Discovery Response
+   Note over EV,EVSE: Service Selection
+   EV ->> EVSE: Service Selection Request
+   EVSE -->> EV: Service Selection Response
+   Note over EV,EVSE: Authorization
+   EV ->> EVSE: Authorization Request (e.g., Plug & Charge, Contract-based)
+   EVSE -->> EV: Authorization Response
+   Note over EV,EVSE: Charging Parameters Setup
+   EV ->> EVSE: Charging Parameters Request
+   EVSE -->> EV: Charging Parameters Response
+   Note over EV,EVSE: Charging
+   EV ->> EVSE: Power Delivery Request (Start Charging)
+   EVSE -->> EV: Power Delivery Response
+   EVSE ->> EV: Power Flow
+   Note over EV,EVSE: Charging Status Updates
+   EV ->> EVSE: Charging Status Request
+   EVSE -->> EV: Charging Status Response
+   Note over EV,EVSE: Termination
+   EV ->> EVSE: Power Delivery Request (Stop Charging)
+   EVSE -->> EV: Power Delivery Response (End Charging)
+   Note over EV,EVSE: Session Termination
+   EV ->> EVSE: Session Stop Request
+   EVSE -->> EV: Session Stop Response
+
+```
+
+### Two EV to EVSE
+
+```mermaid
+
+sequenceDiagram
+
+   participant EV1 as Electric Vehicle 1 (EV1)
+   participant EV2 as Electric Vehicle 2 (EV2)
+   participant EVSE as Electric Vehicle Supply Equipment (EVSE)
+   Note over EV1,EVSE: EV1 connects and starts charging
+   EV1 ->> EVSE: Physical Connection (PLC)
+   EVSE ->> EV1: SECC Discovery Response
+   EV1 ->> EVSE: Session Setup Request
+   EVSE -->> EV1: Session Setup Response
+   EV1 ->> EVSE: Service Discovery Request
+   EVSE -->> EV1: Service Discovery Response
+   EV1 ->> EVSE: Authorization Request
+   EVSE -->> EV1: Authorization Response
+   EV1 ->> EVSE: Power Delivery Request (Start Charging)
+   EVSE -->> EV1: Power Delivery Response
+   EVSE ->> EV1: Power Flow (100%)
+   Note over EV1 and EV2: EV2 connects while EV1 is charging
+   EV2 ->> EVSE: Physical Connection (PLC)
+   EVSE ->> EV2: SECC Discovery Response
+   EV2 ->> EVSE: Session Setup Request
+   EVSE -->> EV2: Session Setup Response
+   EV2 ->> EVSE: Service Discovery Request
+   EVSE -->> EV2: Service Discovery Response
+   EV2 ->> EVSE: Authorization Request
+   EVSE -->> EV2: Authorization Response
+   Note over EV1 and EV2: Power shift occurs
+   EVSE ->> EV1: Power Reduction Request (50%)
+   EV1 -->> EVSE: Power Reduction Acknowledgment
+   EVSE ->> EV2: Power Delivery Request (50%)
+   EV2 -->> EVSE: Power Delivery Response
+   EVSE ->> EV1: Power Flow (50%)
+   EVSE ->> EV2: Power Flow (50%)
+   Note over EV2: EV2 finishes charging
+   EV2 ->> EVSE: Power Delivery Request (Stop Charging)
+   EVSE -->> EV2: Power Delivery Response (End Charging)
+   EV2 ->> EVSE: Session Stop Request
+   EVSE -->> EV2: Session Stop Response
+   EVSE ->> EV1: Power Delivery Request (100%)
+   EV1 -->> EVSE: Power Delivery Response
+   EVSE ->> EV1: Power Flow (100%)
+   Note over EV1: EV1 finishes charging
+   EV1 ->> EVSE: Power Delivery Request (Stop Charging)
+   EVSE -->> EV1: Power Delivery Response (End Charging)
+   EV1 ->> EVSE: Session Stop Request
+   EVSE -->> EV1: Session Stop Response
+
+```
+
+### OCPP Demos
+
+```mermaid
+
+sequenceDiagram
+
+   participant EV as Electric Vehicle (EV)
+   participant EVSE as Electric Vehicle Supply Equipment (EVSE)
+   participant CS as Central System (CS)
+   Note over EV,EVSE: EV connects to EVSE
+   EV ->> EVSE: Physical Connection
+   Note over EVSE,CS: Authorization phase
+   EVSE ->> CS: Authorize.req (RFID/ID)
+   CS -->> EVSE: Authorize.conf (Accepted)
+   Note over EVSE: EVSE starts charging session
+   EVSE ->> CS: StartTransaction.req (Session ID, EV info)
+   CS -->> EVSE: StartTransaction.conf (Accepted)
+   Note over EVSE,EV: Charging starts
+   EVSE ->> EV: Power Flow (Charging)
+   Note over EVSE,CS: Periodic meter values reporting
+   EVSE ->> CS: MeterValues.req (Energy consumption)
+   CS -->> EVSE: MeterValues.conf (Acknowledgment)
+   Note over EV,EVSE: EV requests to stop charging
+   EV ->> EVSE: Stop Charging Request (Unplug)
+   Note over EVSE,CS: Charging session ends
+   EVSE ->> CS: StopTransaction.req (Final meter values, session end)
+   CS -->> EVSE: StopTransaction.conf (Acknowledged)
+   Note over EVSE: EVSE stops charging
+   EVSE ->> EV: Power Flow Stops
+
+```

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ Below is a table of demonstrations that are currently available.
 
    - Note: The terminal should return "Docker version x.x.x".
 
-3. Open the Docker desktop application and navigate to the terminal at the bottom of the screen. 
+3. Open the Docker desktop application
+   
+4. Open your machines terminal
 
 # Step 1: Select the Demo
 
-Copy and paste the command for the demo you wish to run into the Docker terminal within the Docker desktop.
+Copy and paste the command for the demo you wish to run into the machines terminal.
 
-   - Note: Each demonstration has a brief description in the "Content" column and high-level diagram in the "Diagram" column. 
+   - Note: After you enter the command into the terminal, the docker application should open the associated containers
 
 ### Demo Commands 
 
@@ -134,6 +136,12 @@ the EVerest Demo Repository
 3. Add the `curl` script to the "Demo Commands" list
 4. If there is any additional functionality not covered in the current documentation
 please add the details to the "Additional Functionality" section
+
+# Reference Material
+
+- [ISO 15118-2 Documentation](https://www.typhoon-hil.com/documentation/typhoon-hil-software-manual/References/iso15118_protocol.html)
+- [OCPP 2.0.1 Documentation](https://openchargealliance.org/my-oca/ocpp/)
+  
 
 # Appendix Diagrams
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below is a table of demonstrations that are currently available.
 | **One EV ↔ EVSE (AC Simulation)** | Simple AC charging session with one EV connecting to one Charger (EVSE) | [One EV ↔ EVSE (AC Simulation) Diagram](#one-ev-to-evse-ac-simulation) |
 | **One EV ↔ EVSE (ISO 15118-2 DC)** | ISO 15118-2 compliant charging session with one EV connecting to one EVSE | [One EV ↔ EVSE (ISO 15118-2 DC) Diagram](#one-ev-to-evse-iso-15118-2-dc)|
 | **Two EV ↔ EVSE** | Two EVSE connector points showcasing EVerests ability to work with a CSMS in a multi-station context | [Two EV ↔ EVSE Diagram](#two-ev-to-evse) |
-| **E2E Automated Tests** | Performs an automated test of a full charging session| N/A |
+| **E2E Automated Tests** | Performs an automated test of a full charging session| [E2E Automated Tests Diagram](e2e-automated-tests) |
 | **OCPP Demos** | Various OCPP 1.6J and 2.0.1 compliant charging sessions with differing security profiles| [OCPP Demo Diagram](#ocpp-demos)|
 
 ## Operating System Specific Instructions
@@ -172,6 +172,9 @@ please add the details to the "Additional Functionality" section
 
 ## Reference Material
 
+For more information around ISO 15118-2 and OCPP messaging,
+see the below standards documentation.
+
 - [ISO 15118-2 Documentation](https://www.typhoon-hil.com/documentation/typhoon-hil-software-manual/References/iso15118_protocol.html)
 - [OCPP 2.0.1 Documentation](https://openchargealliance.org/my-oca/ocpp/)
   
@@ -270,6 +273,29 @@ sequenceDiagram
    EVSE -->> EV1: Power Delivery Response (End Charging)
    EV1 ->> EVSE: Session Stop Request
    EVSE -->> EV1: Session Stop Response
+
+```
+
+### E2E Automated Tests
+
+```mermaid
+
+sequenceDiagram
+
+participant EVerest
+participant Probe Module
+participant MQTT
+par docker boots
+EVerest ->> EVerest: Boot
+Probe Module ->> Probe Module: init
+end
+Probe Module ->> MQTT: subcribe to session_event
+Note over EVerest, MQTT: Test
+Probe Module ->> EVerest: call_command 
+loop timeout or events
+    Probe Module->>MQTT: get message
+    Probe Module->>Probe Module: assert
+end
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Below is a table of demonstrations that are currently available.
 
 1. Install docker with the following link [Get Docker](https://docs.docker.com/get-docker/)
 
-   - Note: When running the demonstrations, use the Docker desktop terminal for the best results. However, demonstration commands can be posted directly into your machine's terminal if running on Windows or Linux systems.
-
 2. Ensure that docker is installed by opening your machines terminal and typing `docker --version`
 
    - Note: The terminal should return "Docker version x.x.x".

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Below is a table of demonstrations that are currently available.
 
 - Mac OS
   - EVerest Demos are currently NOT supported on M1 chips
+  - On x86 chips, no additional steps needed, move to [Install and Set-up](Install-and-Set-up)
 - Linux
   - No additional steps needed, move to [Install and Set-up](Install-and-Set-up)
 - Windows
@@ -175,7 +176,7 @@ please add the details to the "Additional Functionality" section
 For more information around ISO 15118-2 and OCPP messaging,
 see the below standards documentation.
 
-- [ISO 15118-2 Documentation](https://www.typhoon-hil.com/documentation/typhoon-hil-software-manual/References/iso15118_protocol.html)
+- [ISO 15118-2 Documentation](https://www.iso.org/obp/ui/en/#iso:std:iso:15118:-2:ed-1:v1:en)
 - [OCPP 2.0.1 Documentation](https://openchargealliance.org/my-oca/ocpp/)
   
 ## Appendix Diagrams

--- a/README.md
+++ b/README.md
@@ -156,9 +156,6 @@ sequenceDiagram
     participant EV as Electric Vehicle (EV)
     participant EVSE as Electric Vehicle Supply Equipment (EVSE)
     EV->>EVSE: Plug-in
-    EVSE-->>EV: Proximity Check (PP Signal)
-    EV->>EVSE: Detect Proximity
-    EVSE-->>EV: Control Pilot Signal
     EV->>EVSE: Signal Response (State A to State B1)
     EVSE-->>EV: Power Available?
     EV-->>EVSE: Ready to Charge (State B2)
@@ -166,7 +163,6 @@ sequenceDiagram
     Note over EVSE, EV: Charging in progress
     EV->>EVSE: Request Stop (State C2 to State B)
     EVSE-->>EV: Power Cut Off
-    EVSE-->>EV: Control Pilot Signal (State B)
     EV->>EVSE: Unplug (State A)
     Note over EVSE, EV: Session Ends
  
@@ -182,17 +178,7 @@ sequenceDiagram
    participant EVSE as Electric Vehicle Supply Equipment (EVSE)
    Note over EV,EVSE: Connection Establishment
    EV ->> EVSE: Physical Connection (PLC)
-   EVSE ->> EV: SECC Discovery Response
-   Note over EV,EVSE: Session Setup
-   EV ->> EVSE: Session Setup Request
-   EVSE -->> EV: Session Setup Response
-   Note over EV,EVSE: Service Discovery
-   EV ->> EVSE: Service Discovery Request
-   EVSE -->> EV: Service Discovery Response
-   Note over EV,EVSE: Service Selection
-   EV ->> EVSE: Service Selection Request
-   EVSE -->> EV: Service Selection Response
-   Note over EV,EVSE: Authorization
+   EVSE <<->> EV: ISO 15118-2 communications
    EV ->> EVSE: Authorization Request (e.g., Plug & Charge, Contract-based)
    EVSE -->> EV: Authorization Response
    Note over EV,EVSE: Charging Parameters Setup
@@ -225,25 +211,13 @@ sequenceDiagram
    participant EVSE as Electric Vehicle Supply Equipment (EVSE)
    Note over EV1,EVSE: EV1 connects and starts charging
    EV1 ->> EVSE: Physical Connection (PLC)
-   EVSE ->> EV1: SECC Discovery Response
-   EV1 ->> EVSE: Session Setup Request
-   EVSE -->> EV1: Session Setup Response
-   EV1 ->> EVSE: Service Discovery Request
-   EVSE -->> EV1: Service Discovery Response
-   EV1 ->> EVSE: Authorization Request
-   EVSE -->> EV1: Authorization Response
+   EVSE <<->> EV1: ISO 15118-2 communications
    EV1 ->> EVSE: Power Delivery Request (Start Charging)
    EVSE -->> EV1: Power Delivery Response
    EVSE ->> EV1: Power Flow (100%)
    Note over EV1 and EV2: EV2 connects while EV1 is charging
    EV2 ->> EVSE: Physical Connection (PLC)
-   EVSE ->> EV2: SECC Discovery Response
-   EV2 ->> EVSE: Session Setup Request
-   EVSE -->> EV2: Session Setup Response
-   EV2 ->> EVSE: Service Discovery Request
-   EVSE -->> EV2: Service Discovery Response
-   EV2 ->> EVSE: Authorization Request
-   EVSE -->> EV2: Authorization Response
+   EVSE ->> EV2: ISO 15118-2 communications
    Note over EV1 and EV2: Power shift occurs
    EVSE ->> EV1: Power Reduction Request (50%)
    EV1 -->> EVSE: Power Reduction Acknowledgment


### PR DESCRIPTION
Updated the EVerest Demo README to improve readability, set-up instructions, and include mermaid diagrams of the various demonstrations that are included in the repository.

- The team re-designed the EVerest Demo README to improve: readability, flow of instructions, and showcasing demonstration capabilities.
- After various sessions with the JOET team we determined this would be the best design for the README based on logical flow of information and readability for user types across the EV ecosystem (i.e., varying levels of experience with EV charging + code comprehension).

@shankari, per your most recent comments, here are our additions + changes:
- [Added] end to end testing mermaid diagram with messages between Everest, Probe Module, and MQTT Broker and hyperlinked the diagram within the Demo Table
- [Removed] language surrounding running the demo scripts in the Docker Terminal
- [Added] language that directs the user to run the demo scripts in the machine's terminal
- [Removed] CP + PP + all granular ISO messages from the mermaid diagrams across the "Appendix Diagrams" section (in regards to comment on line 261-263)
- [Added] ISO 15118-2 and OCPP 2.0.1 documentation in a new section "Reference Material" to provide additional context on the message flow during charging session
- [Removed] The OCPP 1.6J demonstration pertinent additional functionality
- [Added] Added step-by-step guidelines for users to contribute demonstrations + update documentation to the demonstration repo
- [Conducted] Codacy Analysis check - fixed errors EXCEPT adding in an image to the`.img` but adding the file to this PR so the new PR owner can add it to the `.img` folder
<img width="332" alt="One_EV_EVSE_UI" src="https://github.com/user-attachments/assets/628ba5c3-7c3a-4094-999b-f298e9190f60">
