### PR TITLE
comment out line in python-iso15118 that causes OSError on M1 mac

### DIFF
--- a/manager/demo-patch-scripts/apply-runtime-patches.sh
+++ b/manager/demo-patch-scripts/apply-runtime-patches.sh
@@ -12,6 +12,8 @@ echo "Applying pyjosev_module_enabledt.patch"
 cd / && patch -p0 -N -i /tmp/demo-patches/pyjosev_module_enabledt.patch
 echo "Applying simulator_enabledt.patch"
 cd / && patch -p0 -N -i /tmp/demo-patches/simulator_enabledt.patch
+echo "Applying iso15118_prevent_m1_crash.patch"
+cd / && patch -p0 -N -i /tmp/demo-patches/iso15118_prevent_m1_crash.patch
 
 echo "Applying enabled_payment_method_in_python.patch"
 cd /ext && patch -p0 -i /tmp/demo-patches/enable_payment_method_in_python.patch

--- a/manager/demo-patches/iso15118_prevent_m1_crash.patch
+++ b/manager/demo-patches/iso15118_prevent_m1_crash.patch
@@ -1,0 +1,10 @@
+--- /ext/dist/libexec/everest/3rd_party/josev/iso15118/evcc/transport/udp_client.py
++++ /ext/dist/libexec/everest/3rd_party/josev/iso15118/evcc/transport/udp_client.py 
+@@ -65,7 +65,7 @@
+         # as the dual of bind(), in the server side, since bind() controls which
+         # interface(s) the socket receives multicast packets from.
+         interface_index = socket.if_nametoindex(iface)
+-        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_IF, interface_index)
++        # sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MULTICAST_IF, interface_index)
+ 
+         return sock


### PR DESCRIPTION
Calling `setsockopt` with `socket.IPPROTO_IPV6` and `socket.IPV6_MULTICAST` returns "OSError 92 Protocol not available" on Apple Silicon Macs, described in https://github.com/EVerest/everest-demo/issues/63.

This would be a temporary fix that disables that line, charging still appears to work with the line commented out.