### PR TITLE
💩 🔧 Configure the demo to use pre-built images for the notify limit c…

### DIFF
--- a/docker-compose.ocpp201.yml
+++ b/docker-compose.ocpp201.yml
@@ -10,7 +10,7 @@ services:
       driver: none
 
   manager:
-    image: ghcr.io/everest/everest-demo/manager:${TAG}
+    image: ghcr.io/everest/everest-demo/manager:working_notify_limit
     platform: linux/x86_64
     deploy:
       resources:
@@ -28,7 +28,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   nodered:
-    image: ghcr.io/everest/everest-demo/nodered:${TAG}
+    image: ghcr.io/everest/everest-demo/nodered:working_notify_limit
     depends_on:
       - mqtt-server
     ports:

--- a/maeve/docker-compose.yml
+++ b/maeve/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       retries: 3
 
   gateway:
-    image: ghcr.io/everest/everest-demo/maeve-gateway:${TAG}
+    image: ghcr.io/everest/everest-demo/maeve-gateway:0.0.23
     depends_on:
       mqtt:
         condition: service_healthy
@@ -67,7 +67,7 @@ services:
     user: "${UID}:${GID}"
 
   manager:
-    image: ghcr.io/everest/everest-demo/maeve-manager:${TAG}
+    image: ghcr.io/everest/everest-demo/maeve-manager:working_notify_limit
     build:
       context: manager
     depends_on:

--- a/manager/config-sil-ocpp201-pnc.yaml
+++ b/manager/config-sil-ocpp201-pnc.yaml
@@ -129,6 +129,9 @@ active_modules:
       evse_manager:
         - module_id: evse_manager_1
           implementation_id: evse
+      ocpp:
+        - module_id: ocpp
+          implementation_id: ocpp_generic
       error_history:
         - module_id: error_history
           implementation_id: error_history


### PR DESCRIPTION
…hanges

Changes:
- EVerest manager uses the changes to receive a limit through the API, pass it through to the OCPP module, store it in the database and use it to influence the power limits
- Node-red sends the correct MQTT messages
- MaEVe manager has an NOP implementation of notify limit

The actual changes/patches are listed here and will need to be merged in one step at a time
https://github.com/EVerest/everest-demo/issues/101#issuecomment-2614915730

Testing done:
```
$ bash demo-iso15118-2-ocpp-201.sh -1 -r $(pwd) -m
$ docker exec -it everest-ac-demo-manager-1 /bin/bas
(container) $ sh /ext/build/run-scripts/run-sil-ocpp201-pnc.sh
```

Then
- moved the slider to various points, the max current changed
- plugged in car, handshake was successful
- moved the slider while the car was plugged in, max current changed and power drawn changed
- cleared limit, max current went to 16 and max power went to 11kW