### PR TITLE
three_phase -> three_phases

### DIFF
--- a/manager/config-sil-ocpp201-pnc.yaml
+++ b/manager/config-sil-ocpp201-pnc.yaml
@@ -54,7 +54,7 @@ active_modules:
       auto_enable: true
       auto_exec: false
       auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
-      three_phase: false
+      three_phases: false
     connections:
       ev_board_support:
         - module_id: yeti_driver_1


### PR DESCRIPTION
I got in a hurry and mistyped something when I was transferring over the changes, there need to be an S in the config.