### PR TITLE
Bump up to the most recent release

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ reconfiguring so that it works.
 Steps (can be edited to be more clear, currently only works for the OCPP 201 demo):
 
 - Set up the CSMS:
-    - run the `demo-iso15118-2-ocpp-201.sh` script to set up the CSMS
-    - delete the everest containers
+  - run the `demo-iso15118-2-ocpp-201.sh` script to set up the CSMS
+  - delete the everest containers
 - Set the `CONTAINER_EXT_PATH` variable to the location where you would like
   the everest source and dist to go. It should be an absolute path
   `export CONTAINER_EXT_PATH=/Users/...`
@@ -354,7 +354,7 @@ Steps (can be edited to be more clear, currently only works for the OCPP 201 dem
   parallel with the precompiled version for comparison.
   `docker compose -f docker-compose.ocpp201.dev.yml --project-name everest-dev-ocpp up -d`
 - Once the container has started, in the container:
-    - `(container)# bash /tmp/os-pkg-install.sh && bash /tmp/initial-install.sh`
+  - `(container)# bash /tmp/os-pkg-install.sh && bash /tmp/initial-install.sh`
 - You should now have the source code available at `$CONTAINER_EXT_PATH/source`.
   `$CONTAINER_EXT_PATH/cache` (for libraries) and `$CONTAINER_EXT_PATH/dist`
    (for the binary distribution) might also be helpful
@@ -363,9 +363,9 @@ Steps (can be edited to be more clear, currently only works for the OCPP 201 dem
   happen after the initial compile because that pulls down the libraries
   `bash /tmp/demo-patch-scripts/apply-library-patches.sh`
 - The build-deploy-test cycle would then be:
-    - make changes in `$CONTAINER_EXT_PATH` using the editor of your choice
-    - build in the container: `bash /tmp/dev-build-install-configure.sh`
-    - deploy in the container: `sh /ext/build/run-scripts/run-sil-ocpp201-pnc.sh`
+  - make changes in `$CONTAINER_EXT_PATH` using the editor of your choice
+  - build in the container: `bash /tmp/dev-build-install-configure.sh`
+  - deploy in the container: `sh /ext/build/run-scripts/run-sil-ocpp201-pnc.sh`
 - After your changes are finalized, don't forget to convert them into patches
   using `git diff` and putting them into the manager so that the final
   precompiled images can be pushed up

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ these containers, so it can be edited locally, and for compiling and
 reconfiguring so that it works.
 
 Steps (can be edited to be more clear, currently only works for the OCPP 201 demo):
+
 - Set up the CSMS:
     - run the `demo-iso15118-2-ocpp-201.sh` script to set up the CSMS
     - delete the everest containers
@@ -357,6 +358,7 @@ Steps (can be edited to be more clear, currently only works for the OCPP 201 dem
 - You should now have the source code available at `$CONTAINER_EXT_PATH/source`.
   `$CONTAINER_EXT_PATH/cache` (for libraries) and `$CONTAINER_EXT_PATH/dist`
    (for the binary distribution) might also be helpful
+- Compile for the first time `bash /tmp/dev-build-install-configure.sh`
 - Apply library patches; you should only need to do this once, but it must
   happen after the initial compile because that pulls down the libraries
   `bash /tmp/demo-patch-scripts/apply-library-patches.sh`
@@ -367,6 +369,8 @@ Steps (can be edited to be more clear, currently only works for the OCPP 201 dem
 - After your changes are finalized, don't forget to convert them into patches
   using `git diff` and putting them into the manager so that the final
   precompiled images can be pushed up
-
-
-- Create the initial installation ``
+- On MaEVe, if you want to register the dev station with a different
+  `station_id` (maybe so that you can compare the behavior with and without
+  your changes, you can edit the `docker-compose.ocpp201.dev.yml` and change
+  `cp001` to (say) `cpdev`.  In that case, you will also need to add the station
+  to the CSMS - e.g.  `DEMO_VERSION=sp1 CHARGE_STATION_ID=cpdev bash maeve/add-charger-and-rfid-card.sh`

--- a/README.md
+++ b/README.md
@@ -329,3 +329,44 @@ sequenceDiagram
    EVSE ->> EV: Power Flow Stops
 
 ```
+
+### Setting up an dev environment using the containers
+
+While the containers above are great for running and testing, it is hard to
+make changes on them because the files need to be edited within the container.
+This can be challenging since developers cannot use standard IDE tools, the
+steps to reinstall after compiling are convoluted, etc.
+
+This repo now contains support for mounting source code as a volume in one of
+these containers, so it can be edited locally, and for compiling and
+reconfiguring so that it works.
+
+Steps (can be edited to be more clear, currently only works for the OCPP 201 demo):
+- Set up the CSMS:
+    - run the `demo-iso15118-2-ocpp-201.sh` script to set up the CSMS
+    - delete the everest containers
+- Set the `CONTAINER_EXT_PATH` variable to the location where you would like
+  the everest source and dist to go. It should be an absolute path
+  `export CONTAINER_EXT_PATH=/Users/...`
+- Ensure that the path exists (`$ mkdir -p $CONTAINER_EXT_PATH`)
+- Run `docker-compose.ocpp201.dev.yml`. Set the name if you want to run it in
+  parallel with the precompiled version for comparison.
+  `docker compose -f docker-compose.ocpp201.dev.yml --project-name everest-dev-ocpp up -d`
+- Once the container has started, in the container:
+    - `(container)# bash /tmp/os-pkg-install.sh && bash /tmp/initial-install.sh`
+- You should now have the source code available at `$CONTAINER_EXT_PATH/source`.
+  `$CONTAINER_EXT_PATH/cache` (for libraries) and `$CONTAINER_EXT_PATH/dist`
+   (for the binary distribution) might also be helpful
+- Apply library patches; you should only need to do this once, but it must
+  happen after the initial compile because that pulls down the libraries
+  `bash /tmp/demo-patch-scripts/apply-library-patches.sh`
+- The build-deploy-test cycle would then be:
+    - make changes in `$CONTAINER_EXT_PATH` using the editor of your choice
+    - build in the container: `bash /tmp/dev-build-install-configure.sh`
+    - deploy in the container: `sh /ext/build/run-scripts/run-sil-ocpp201-pnc.sh`
+- After your changes are finalized, don't forget to convert them into patches
+  using `git diff` and putting them into the manager so that the final
+  precompiled images can be pushed up
+
+
+- Create the initial installation ``

--- a/citrineos/apply-patches.sh
+++ b/citrineos/apply-patches.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export CSMS_SP1_URL="ws://host.docker.internal:8082/cp001"
-export CSMS_SP2_URL="wss://host.docker.internal:8443/cp001"
-export CSMS_SP3_URL="wss://host.docker.internal:8444/cp001"
+export CSMS_SP1_BASE="ws://host.docker.internal:8082"
+export CSMS_SP2_BASE="wss://host.docker.internal:8443"
+export CSMS_SP3_BASE="wss://host.docker.internal:8444"

--- a/demo-iso15118-2-ocpp-201.sh
+++ b/demo-iso15118-2-ocpp-201.sh
@@ -98,10 +98,10 @@ fi
   cp ../manager/cached_certs_correct_name_emaid.tar.gz .
 
   if [[ "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
-    source ../${DEMO_CSMS}/copy-certs.sh
+      source "../$DEMO_CSMS/copy-certs.sh"
   fi
 
-  source ../${DEMO_CSMS}/apply-runtime-patches.sh
+  source "../$DEMO_CSMS/apply-runtime-patches.sh"
 
   echo "CSMS_SP1_BASE:     $CSMS_SP1_BASE"
   echo "CSMS_SP2_BASE:     $CSMS_SP2_BASE"
@@ -119,8 +119,8 @@ fi
   sleep 5
 
   echo "Adding a charger and RFID card to ${DEMO_CSMS}"
-  source ../${DEMO_CSMS}/add-charger-and-rfid-card.sh
-
+  source "../{$DEMO_CSMS}/add-charger-and-rfid-card.sh"
+  
   popd || exit 1
 # END: Setting up the CSMS
 
@@ -129,11 +129,11 @@ echo "API calls to CSMS finished, Starting everest"
 docker compose --project-name everest-ac-demo --file "${DEMO_COMPOSE_FILE_NAME}" up -d --wait
 docker cp manager/config-sil-ocpp201-pnc.yaml  everest-ac-demo-manager-1:/ext/source/config/config-sil-ocpp201-pnc.yaml
 docker exec \
-        -e DEMO_VERSION=${DEMO_VERSION} \
-        -e CSMS_SP1_BASE=${CSMS_SP1_BASE} \
-        -e CSMS_SP2_BASE=${CSMS_SP2_BASE} \
-        -e CSMS_SP3_BASE=${CSMS_SP3_BASE} \
-        -e CHARGE_STATION_ID=${CHARGE_STATION_ID} \
+        -e DEMO_VERSION="${DEMO_VERSION}" \
+        -e CSMS_SP1_BASE="${CSMS_SP1_BASE}" \
+        -e CSMS_SP2_BASE="${CSMS_SP2_BASE}" \
+        -e CSMS_SP3_BASE="${CSMS_SP3_BASE}" \
+        -e CHARGE_STATION_ID="${CHARGE_STATION_ID}" \
         everest-ac-demo-manager-1 \
         /bin/bash /tmp/ocpp201-sp-config.sh
 

--- a/demo-iso15118-2-ocpp-201.sh
+++ b/demo-iso15118-2-ocpp-201.sh
@@ -3,6 +3,7 @@
 
 DEMO_REPO="https://github.com/everest/everest-demo.git"
 DEMO_BRANCH="main"
+CHARGE_STATION_ID="cp001"
 
 START_OPTION="auto"
 
@@ -16,6 +17,7 @@ directory to the -r option (e.g., '-r \$(pwd)').
 where:
     -r   URL to everest-demo repo to use (default: $DEMO_REPO, '$PWD' uses the current dir)
     -b   Branch of everest-demo repo to use (default: $DEMO_BRANCH)
+    -s   Charge Station ID (cp001 by default)
     -1   OCPP v2.0.1 Security Profile 1
     -2   OCPP v2.0.1 Security Profile 2
     -3   OCPP v2.0.1 Security Profile 3
@@ -29,10 +31,11 @@ DEMO_COMPOSE_FILE_NAME="docker-compose.ocpp201.yml"
 DEMO_CSMS=maeve
 
 # loop through positional options/arguments
-while getopts ':r:b:123chm' option; do
+while getopts ':r:b:s:123chm' option; do
   case "$option" in
     r)  DEMO_REPO="$OPTARG" ;;
     b)  DEMO_BRANCH="$OPTARG" ;;
+    s)  CHARGE_STATION_ID="$OPTARG" ;;
     1)  DEMO_VERSION="v2.0.1-sp1" ;;
     2)  DEMO_VERSION="v2.0.1-sp2" ;;
     3)  DEMO_VERSION="v2.0.1-sp3" ;;
@@ -73,9 +76,7 @@ echo "DEMO VERSION:     $DEMO_VERSION"
 echo "DEMO CONFIG:      $DEMO_COMPOSE_FILE_NAME"
 echo "DEMO DIR:         $DEMO_DIR"
 echo "DEMO CSMS:        $DEMO_CSMS"
-echo "CSMS_SP1_URL:     $CSMS_SP1_URL"
-echo "CSMS_SP2_URL:     $CSMS_SP2_URL"
-echo "CSMS_SP3_URL:     $CSMS_SP3_URL"
+echo "CHARGE STATION:   $CHARGE_STATION_ID"
 
 
 cd "${DEMO_DIR}" || exit 1
@@ -102,6 +103,10 @@ fi
 
   source ../${DEMO_CSMS}/apply-runtime-patches.sh
 
+  echo "CSMS_SP1_BASE:     $CSMS_SP1_BASE"
+  echo "CSMS_SP2_BASE:     $CSMS_SP2_BASE"
+  echo "CSMS_SP3_BASE:     $CSMS_SP3_BASE"
+
   if ! docker compose --project-name "${DEMO_CSMS}"-csms up -d --wait; then
       echo "Failed to start ${DEMO_CSMS}"
       exit 1
@@ -125,9 +130,10 @@ docker compose --project-name everest-ac-demo --file "${DEMO_COMPOSE_FILE_NAME}"
 docker cp manager/config-sil-ocpp201-pnc.yaml  everest-ac-demo-manager-1:/ext/source/config/config-sil-ocpp201-pnc.yaml
 docker exec \
         -e DEMO_VERSION=${DEMO_VERSION} \
-        -e CSMS_SP1_URL=${CSMS_SP1_URL} \
-        -e CSMS_SP2_URL=${CSMS_SP2_URL} \
-        -e CSMS_SP3_URL=${CSMS_SP3_URL} \
+        -e CSMS_SP1_BASE=${CSMS_SP1_BASE} \
+        -e CSMS_SP2_BASE=${CSMS_SP2_BASE} \
+        -e CSMS_SP3_BASE=${CSMS_SP3_BASE} \
+        -e CHARGE_STATION_ID=${CHARGE_STATION_ID} \
         everest-ac-demo-manager-1 \
         /bin/bash /tmp/ocpp201-sp-config.sh
 

--- a/demo-iso15118-2-ocpp-201.sh
+++ b/demo-iso15118-2-ocpp-201.sh
@@ -25,7 +25,7 @@ where:
 
 
 DEMO_VERSION=
-DEMO_COMPOSE_FILE_NAME=
+DEMO_COMPOSE_FILE_NAME="docker-compose.ocpp201.yml"
 DEMO_CSMS=maeve
 
 # loop through positional options/arguments
@@ -33,12 +33,9 @@ while getopts ':r:b:123chm' option; do
   case "$option" in
     r)  DEMO_REPO="$OPTARG" ;;
     b)  DEMO_BRANCH="$OPTARG" ;;
-    1)  DEMO_VERSION="v2.0.1-sp1"
-        DEMO_COMPOSE_FILE_NAME="docker-compose.ocpp201.yml" ;;
-    2)  DEMO_VERSION="v2.0.1-sp2"
-        DEMO_COMPOSE_FILE_NAME="docker-compose.ocpp201.yml" ;;
-    3)  DEMO_VERSION="v2.0.1-sp3"
-        DEMO_COMPOSE_FILE_NAME="docker-compose.ocpp201.yml" ;;
+    1)  DEMO_VERSION="v2.0.1-sp1" ;;
+    2)  DEMO_VERSION="v2.0.1-sp2" ;;
+    3)  DEMO_VERSION="v2.0.1-sp3" ;;
     c)  DEMO_CSMS="citrineos" ;;
     m)  START_OPTION="manual" ;;
     h)  echo -e "$usage"; exit ;;
@@ -126,30 +123,13 @@ pushd everest-demo || exit 1
 echo "API calls to CSMS finished, Starting everest"
 docker compose --project-name everest-ac-demo --file "${DEMO_COMPOSE_FILE_NAME}" up -d --wait
 docker cp manager/config-sil-ocpp201-pnc.yaml  everest-ac-demo-manager-1:/ext/source/config/config-sil-ocpp201-pnc.yaml
-docker exec everest-ac-demo-manager-1 rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/EVSE_2.json
-docker exec everest-ac-demo-manager-1 rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/Connector_2_1.json
-
-if [[ "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
-  docker cp manager/cached_certs_correct_name_emaid.tar.gz everest-ac-demo-manager-1:/ext/source/build
-  docker exec everest-ac-demo-manager-1 /bin/bash -c "pushd /ext/source/build && tar xf cached_certs_correct_name_emaid.tar.gz"
-
-  echo "Configured everest certs, validating that the chain is set up correctly"
-  docker exec everest-ac-demo-manager-1 /bin/bash -c "pushd /ext/source/build && openssl verify -show_chain -CAfile dist/etc/everest/certs/ca/v2g/V2G_ROOT_CA.pem --untrusted dist/etc/everest/certs/ca/csms/CPO_SUB_CA1.pem --untrusted dist/etc/everest/certs/ca/csms/CPO_SUB_CA2.pem dist/etc/everest/certs/client/csms/CSMS_LEAF.pem"
-fi
-
-if [[ "$DEMO_VERSION" =~ sp1 ]]; then
-echo "Configured to SecurityProfile: 1, disabling TLS and configuring server to ${CSMS_SP1_URL}"
-docker exec everest-ac-demo-manager-1 /bin/bash -c "sed -i 's#ws://localhost:9000#${CSMS_SP1_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json"
-docker cp manager/disable_iso_tls.patch everest-ac-demo-manager-1:/tmp/
-docker exec everest-ac-demo-manager-1 /bin/bash -c "pushd /ext/source && patch -p0 -i /tmp/disable_iso_tls.patch"
-elif [[ "$DEMO_VERSION" =~ sp2 ]]; then
-echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP2_URL}"
-docker exec everest-ac-demo-manager-1 /bin/bash -c "sed -i 's#ws://localhost:9000#${CSMS_SP2_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json"
-elif [[ "$DEMO_VERSION" =~ sp3 ]]; then
-echo "Running with SP3, TLS should be enabled"
-echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP3_URL}"
-docker exec everest-ac-demo-manager-1 /bin/bash -c "sed -i 's#ws://localhost:9000#${CSMS_SP3_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json"
-fi
+docker exec \
+        -e DEMO_VERSION=${DEMO_VERSION} \
+        -e CSMS_SP1_URL=${CSMS_SP1_URL} \
+        -e CSMS_SP2_URL=${CSMS_SP2_URL} \
+        -e CSMS_SP3_URL=${CSMS_SP3_URL} \
+        everest-ac-demo-manager-1 \
+        /bin/bash /tmp/ocpp201-sp-config.sh
 
 if [[ "$START_OPTION" == "auto" ]]; then
   echo "Starting software in the loop simulation automatically"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -4,14 +4,15 @@ services:
   mqtt-server:
     image: ghcr.io/everest/everest-demo/mqtt-server:${TAG}
     build: mosquitto
-    platform: linux/x86_64
     logging:
       driver: none
 
   manager:
     image: ghcr.io/everest/everest-demo/manager:${TAG}
-    build: manager
-    platform: linux/x86_64
+    build:
+      context: manager
+      platforms:
+        - linux/arm64
     depends_on:
       - mqtt-server
     environment:

--- a/docker-compose.ocpp201.dev.yml
+++ b/docker-compose.ocpp201.dev.yml
@@ -1,0 +1,40 @@
+version: "3.6"
+
+services:
+  mqtt-server:
+    image: ghcr.io/everest/everest-demo/mqtt-server:${TAG}
+    ports:
+      - 3386:1883 # (CSCS)
+    logging:
+      driver: none
+
+  manager:
+    image: ghcr.io/catarial/everest-ci/build-kit-base:v1.5.2
+    depends_on:
+      - mqtt-server
+    environment:
+      - EVEREST_VERSION=2025.3.0
+      - MQTT_SERVER_ADDRESS=mqtt-server
+      - DEMO_CSMS=maeve
+      - DEMO_VERSION=v2.0.1-sp1
+      - CSMS_SP1_URL=ws://host.docker.internal/ws/cp001
+      - CSMS_SP2_URL=wss://host.docker.internal/ws/cp001
+      - CSMS_SP3_URL=wss://host.docker.internal/ws/cp001
+    entrypoint: "tail -f /dev/null"
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - $CONTAINER_EXT_PATH:/ext
+      - $PWD/manager:/tmp
+
+  nodered:
+    image: ghcr.io/everest/everest-demo/nodered:${TAG}
+    depends_on:
+      - mqtt-server
+    ports:
+      - 3388:1880
+    environment:
+      - MQTT_SERVER_ADDRESS=mqtt-server
+      - FLOWS=/config/config-sil-iso15118-ac-flow.json

--- a/docker-compose.ocpp201.dev.yml
+++ b/docker-compose.ocpp201.dev.yml
@@ -17,9 +17,10 @@ services:
       - MQTT_SERVER_ADDRESS=mqtt-server
       - DEMO_CSMS=maeve
       - DEMO_VERSION=v2.0.1-sp1
-      - CSMS_SP1_URL=ws://host.docker.internal/ws/cp001
-      - CSMS_SP2_URL=wss://host.docker.internal/ws/cp001
-      - CSMS_SP3_URL=wss://host.docker.internal/ws/cp001
+      - CHARGE_STATION_ID=cp001
+      - CSMS_SP1_BASE=ws://host.docker.internal/ws
+      - CSMS_SP2_BASE=wss://host.docker.internal/ws
+      - CSMS_SP3_BASE=wss://host.docker.internal/ws
     entrypoint: "tail -f /dev/null"
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0

--- a/docker-compose.ocpp201.yml
+++ b/docker-compose.ocpp201.yml
@@ -3,15 +3,13 @@ version: "3.6"
 services:
   mqtt-server:
     image: ghcr.io/everest/everest-demo/mqtt-server:${TAG}
-    platform: linux/x86_64
     ports:
       - 2727:1883 # (CSCS)
     logging:
       driver: none
 
   manager:
-    image: ghcr.io/everest/everest-demo/manager:working_notify_limit
-    platform: linux/x86_64
+    image: ghcr.io/everest/everest-demo/manager:${TAG}
     deploy:
       resources:
         limits:
@@ -28,7 +26,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   nodered:
-    image: ghcr.io/everest/everest-demo/nodered:working_notify_limit
+    image: ghcr.io/everest/everest-demo/nodered:${TAG}
     depends_on:
       - mqtt-server
     ports:

--- a/maeve/add-charger-and-rfid-card.sh
+++ b/maeve/add-charger-and-rfid-card.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 
-echo "While running subscript, DEMO_VERSION is " "$DEMO_VERSION"
+CHARGE_STATION_ID=${CHARGE_STATION_ID:-cp001}
+
+echo "While running subscript, DEMO_VERSION is " "$DEMO_VERSION and ${CHARGE_STATION_ID}"
 
 if [[ "$DEMO_VERSION" =~ sp1 ]]; then
   echo "MaEVe CSMS started, adding charge station with Security Profile 1 (note: profiles in MaEVe start with 0 so SP-0 == OCPP SP-1)"
-  curl http://localhost:9410/api/v0/cs/cp001 -H 'content-type: application/json' \
+  curl http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID} -H 'content-type: application/json' \
     -d '{"securityProfile": 0, "base64SHA256Password": "3oGi4B5I+Y9iEkYtL7xvuUxrvGOXM/X2LQrsCwf/knA="}'
 elif [[ "$DEMO_VERSION" =~ sp2 ]]; then
   echo "MaEVe CSMS started, adding charge station with Security Profile 2 (note: profiles in MaEVe start with 0 so SP-1 == OCPP SP-2)"
-  curl http://localhost:9410/api/v0/cs/cp001 -H 'content-type: application/json' \
+  curl http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID} -H 'content-type: application/json' \
     -d '{"securityProfile": 1, "base64SHA256Password": "3oGi4B5I+Y9iEkYtL7xvuUxrvGOXM/X2LQrsCwf/knA="}'
 elif [[ "$DEMO_VERSION" =~ sp3 ]]; then
   echo "MaEVe CSMS started, adding charge station with Security Profile 3 (note: profiles in MaEVe start with 0 so SP-2 == OCPP SP-3)"
-  curl http://localhost:9410/api/v0/cs/cp001 -H 'content-type: application/json' -d '{"securityProfile": 2}'
+  curl http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID} -H 'content-type: application/json' -d '{"securityProfile": 2}'
 fi
 
 echo "Charge station added, adding user token"

--- a/maeve/add-charger-and-rfid-card.sh
+++ b/maeve/add-charger-and-rfid-card.sh
@@ -6,15 +6,15 @@ echo "While running subscript, DEMO_VERSION is " "$DEMO_VERSION and ${CHARGE_STA
 
 if [[ "$DEMO_VERSION" =~ sp1 ]]; then
   echo "MaEVe CSMS started, adding charge station with Security Profile 1 (note: profiles in MaEVe start with 0 so SP-0 == OCPP SP-1)"
-  curl http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID} -H 'content-type: application/json' \
+  curl "http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID}" -H 'content-type: application/json' \
     -d '{"securityProfile": 0, "base64SHA256Password": "3oGi4B5I+Y9iEkYtL7xvuUxrvGOXM/X2LQrsCwf/knA="}'
 elif [[ "$DEMO_VERSION" =~ sp2 ]]; then
   echo "MaEVe CSMS started, adding charge station with Security Profile 2 (note: profiles in MaEVe start with 0 so SP-1 == OCPP SP-2)"
-  curl http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID} -H 'content-type: application/json' \
+  curl "http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID}" -H 'content-type: application/json' \
     -d '{"securityProfile": 1, "base64SHA256Password": "3oGi4B5I+Y9iEkYtL7xvuUxrvGOXM/X2LQrsCwf/knA="}'
 elif [[ "$DEMO_VERSION" =~ sp3 ]]; then
   echo "MaEVe CSMS started, adding charge station with Security Profile 3 (note: profiles in MaEVe start with 0 so SP-2 == OCPP SP-3)"
-  curl http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID} -H 'content-type: application/json' -d '{"securityProfile": 2}'
+  curl "http://localhost:9410/api/v0/cs/${CHARGE_STATION_ID}" -H 'content-type: application/json' -d '{"securityProfile": 2}'
 fi
 
 echo "Charge station added, adding user token"

--- a/maeve/apply-runtime-patches.sh
+++ b/maeve/apply-runtime-patches.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-export CSMS_SP1_URL="ws://host.docker.internal/ws/cp001"
-export CSMS_SP2_URL="wss://host.docker.internal/ws/cp001"
-export CSMS_SP3_URL="wss://host.docker.internal/ws/cp001"
+export CSMS_SP1_BASE="ws://host.docker.internal/ws"
+export CSMS_SP2_BASE="wss://host.docker.internal/ws"
+export CSMS_SP3_BASE="wss://host.docker.internal/ws"
 
   if [[ "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
     echo "Patching the CSMS to enable EVerest organization"

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -1,6 +1,6 @@
-FROM ghcr.io/everest/everest-ci/build-kit-base:v1.4.2
+FROM ghcr.io/catarial/everest-ci/build-kit-base:v1.5.2
 
-ARG EVEREST_VERSION=2024.9.0
+ARG EVEREST_VERSION=2025.3.0
 ENV EVEREST_VERSION=${EVEREST_VERSION}
 
 RUN echo "Copying compile-time patches before starting compile"

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -5,25 +5,16 @@ ENV EVEREST_VERSION=${EVEREST_VERSION}
 
 RUN echo "Copying compile-time patches before starting compile"
 
-COPY demo-patches/ /tmp/demo-patches/
-COPY demo-patch-scripts/ /tmp/demo-patch-scripts/
+COPY . /tmp/
 
 RUN echo "Installing patch and vim"
-RUN apt-get -y -qq update
-RUN apt-get install -y -qq patch
-RUN apt-get install -y -qq vim
+RUN bash /tmp/os-pkg-install.sh
 
 # Cloning the repo now and copying files over
-RUN git clone https://github.com/EVerest/everest-core.git \
-        && cd everest-core \
-        && git checkout ${EVEREST_VERSION} \
-        && cd .. \
-        && mkdir -p /ext/scripts \
-        && cp -r everest-core/.ci/build-kit/scripts/* /ext/scripts/ \
-        && mv everest-core /ext/source \
-        && bash /tmp/demo-patch-scripts/apply-compile-patches.sh \
-        && /entrypoint.sh run-script compile \
-        && /entrypoint.sh run-script install
+RUN echo "Clone and initial compile"
+RUN bash /tmp/initial-install.sh
+RUN /entrypoint.sh run-script compile \
+    && /entrypoint.sh run-script install
 
 # The previous approach works for code patches to the
 # modules in everest-core, which are checked out as part
@@ -36,8 +27,10 @@ RUN git clone https://github.com/EVerest/everest-core.git \
 # build (e.g. between the cmake and the ninja, we could apply
 # it there. But this is what we have to work with :(
 
+RUN echo "Applying library patches"
 RUN bash /tmp/demo-patch-scripts/apply-library-patches.sh
-RUN /entrypoint.sh run-script compile
+RUN /entrypoint.sh run-script compile \
+   && /entrypoint.sh run-script install
 
 # cleanup
 RUN apt-get -y remove --purge build-essential
@@ -46,12 +39,6 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/*
 # Copy over the non-compiled patches *after* compilation and installation
 RUN echo "Applying Post-Build patches..."
 RUN bash /tmp/demo-patch-scripts/apply-runtime-patches.sh
-
-# Setup python stuff for the more complex simulator
-# and for testing if needed
-RUN pip install --break-system-packages numpy==2.1.3
-RUN pip install --break-system-packages control==0.10.1
-RUN pip install --break-system-packages paho-mqtt==2.1.0
 
 COPY run-test.sh /ext/source/tests/run-test.sh
 

--- a/manager/config-sil-ocpp201-pnc.yaml
+++ b/manager/config-sil-ocpp201-pnc.yaml
@@ -54,7 +54,7 @@ active_modules:
       auto_enable: true
       auto_exec: false
       auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
-      three_phases: false
+      three_phases: true
     connections:
       ev_board_support:
         - module_id: yeti_driver_1

--- a/manager/demo-patch-scripts/apply-compile-patches.sh
+++ b/manager/demo-patch-scripts/apply-compile-patches.sh
@@ -2,5 +2,5 @@
 
 echo "Applying compile-time patches"
 
-cd / && patch -p0 -i /tmp/demo-patches/enable_iso_dt.patch
-cd / && patch -p1 -i /tmp/demo-patches/composite_schedule_fixes.patch
+cd / && patch -N -p0 -i /tmp/demo-patches/enable_iso_dt.patch
+cd / && patch -N -p1 -i /tmp/demo-patches/composite_schedule_fixes.patch

--- a/manager/demo-patch-scripts/apply-library-patches.sh
+++ b/manager/demo-patch-scripts/apply-library-patches.sh
@@ -2,4 +2,4 @@
 
 echo "Applying library patches"
 
-cd / && patch -p0 -i /tmp/demo-patches/enable_ocpp_logging.patch
+cd / && patch -N -p0 -i /tmp/demo-patches/enable_ocpp_logging.patch

--- a/manager/demo-patch-scripts/apply-runtime-patches.sh
+++ b/manager/demo-patch-scripts/apply-runtime-patches.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
 echo "Applying comm_session_handler_enabledt.patch"
-cd / && patch -p0 -N -i /tmp/demo-patches/comm_session_handler_enabledt.patch
+cd / && patch -N -p0  -i /tmp/demo-patches/comm_session_handler_enabledt.patch
 echo "Applying ev_state_enabledt.patch"
-cd / && patch -p0 -N -i /tmp/demo-patches/ev_state_enabledt.patch
+cd / && patch -N -p0  -i /tmp/demo-patches/ev_state_enabledt.patch
 echo "Applying iso15118_2_states_enabledt.patch"
-cd / && patch -p0 -N -i /tmp/demo-patches/iso15118_2_states_enabledt.patch
+cd / && patch -N -p0  -i /tmp/demo-patches/iso15118_2_states_enabledt.patch
 echo "Applying jsevmanager_index_enabledt.patch"
-cd / && patch -p0 -N -i /tmp/demo-patches/jsevmanager_index_enabledt.patch
+cd / && patch -N -p0  -i /tmp/demo-patches/jsevmanager_index_enabledt.patch
 echo "Applying pyjosev_module_enabledt.patch"
-cd / && patch -p0 -N -i /tmp/demo-patches/pyjosev_module_enabledt.patch
+cd / && patch -N -p0  -i /tmp/demo-patches/pyjosev_module_enabledt.patch
 echo "Applying simulator_enabledt.patch"
-cd / && patch -p0 -N -i /tmp/demo-patches/simulator_enabledt.patch
+cd / && patch -N -p0  -i /tmp/demo-patches/simulator_enabledt.patch
 echo "Applying iso15118_prevent_m1_crash.patch"
 cd / && patch -p0 -N -i /tmp/demo-patches/iso15118_prevent_m1_crash.patch
 
 echo "Applying enabled_payment_method_in_python.patch"
-cd /ext && patch -p0 -i /tmp/demo-patches/enable_payment_method_in_python.patch
+cd /ext && patch -N -p0 -i /tmp/demo-patches/enable_payment_method_in_python.patch
 echo "Applying support_payment_in_jsevmanager.patch"
-cd /ext/dist/libexec/everest && patch -p1 -i /tmp/demo-patches/support_payment_in_jsevmanager.patch
+cd /ext/dist/libexec/everest && patch -N -p1 -i /tmp/demo-patches/support_payment_in_jsevmanager.patch
 echo "Applying hw_cap_down_to_16A.patch"
-cd / && patch -p0 -i /tmp/demo-patches/hw_cap_down_to_16A.patch
+cd / && patch -N -p0 -i /tmp/demo-patches/hw_cap_down_to_16A.patch
 
 cp /tmp/demo-patches/power_curve.py \
 /ext/dist/libexec/everest/3rd_party/josev/iso15118/evcc/states/

--- a/manager/demo-patches/composite_schedule_fixes.patch
+++ b/manager/demo-patches/composite_schedule_fixes.patch
@@ -19,16 +19,16 @@ index 68c4900d..03425dc4 100644
              this->ocpp_charging_schedule = schedule;
              this->ocpp_charging_schedule_updated = true;
 diff --git a/modules/OCPP201/OCPP201.cpp b/modules/OCPP201/OCPP201.cpp
-index 83f2324b..8eb7900f 100644
+index 0c3d953f..16ae318c 100644
 --- a/ext/source/modules/OCPP201/OCPP201.cpp
 +++ b/ext/source/modules/OCPP201/OCPP201.cpp
-@@ -1181,6 +1181,9 @@ void OCPP201::process_deauthorized(const int32_t evse_id, const int32_t connecto
+@@ -1313,6 +1313,9 @@ void OCPP201::process_reservation_end(const int32_t evse_id, const int32_t conne
  }
- 
- void OCPP201::publish_charging_schedules(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules) {
+
+ void OCPP201::publish_charging_schedules(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules) {
 +    EVLOG_info << "About to publish composite charging schedules: ";
-+    for (ocpp::v201::CompositeSchedule cs: composite_schedules)
-+           EVLOG_info << cs << '\n';
++    for (ocpp::v2::CompositeSchedule cs: composite_schedules)
++        EVLOG_info << cs << '\n';
      const auto everest_schedules = conversions::to_everest_charging_schedules(composite_schedules);
      this->p_ocpp_generic->publish_charging_schedules(everest_schedules);
  }

--- a/manager/demo-patches/enable_ocpp_logging.patch
+++ b/manager/demo-patches/enable_ocpp_logging.patch
@@ -1,33 +1,32 @@
---- /ext/cache/cpm/libocpp/56452082640eeee05feec42f2f502d6beb8e684c/libocpp/lib/ocpp/v201/charge_point.cpp
-+++ /ext/cache/cpm/libocpp/56452082640eeee05feec42f2f502d6beb8e684c/libocpp/lib/ocpp/v201/charge_point.cpp
-@@ -3358,7 +3358,7 @@
+--- /ext/cache/cpm/libocpp/d84451d775fdc545cd345d552061af128c9c2465/libocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
++++ /ext/cache/cpm/libocpp/d84451d775fdc545cd345d552061af128c9c2465/libocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+@@ -696,7 +696,7 @@ void SmartCharging::notify_ev_charging_needs_req(const NotifyEVChargingNeedsRequ
  }
- 
- void ChargePoint::handle_set_charging_profile_req(Call<SetChargingProfileRequest> call) {
+
+ void SmartCharging::handle_set_charging_profile_req(Call<SetChargingProfileRequest> call) {
 -    EVLOG_debug << "Received SetChargingProfileRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
 +    EVLOG_info << "Received SetChargingProfileRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
      auto msg = call.msg;
      SetChargingProfileResponse response;
      response.status = ChargingProfileStatusEnum::Rejected;
-@@ -3383,7 +3383,7 @@
+@@ -721,7 +721,7 @@ void SmartCharging::handle_set_charging_profile_req(Call<SetChargingProfileReque
          response.statusInfo = StatusInfo();
          response.statusInfo->reasonCode = "InvalidValue";
          response.statusInfo->additionalInfo = "ChargingStationExternalConstraintsInSetChargingProfileRequest";
 -        EVLOG_debug << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
 +        EVLOG_info << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
                      << "\nadditionalInfo: " << response.statusInfo->additionalInfo->get();
- 
+
          ocpp::CallResult<SetChargingProfileResponse> call_result(response, call.uniqueId);
-@@ -3394,10 +3394,10 @@
- 
-     response = this->smart_charging_handler->validate_and_add_profile(msg.chargingProfile, msg.evseId);
+@@ -732,10 +732,10 @@ void SmartCharging::handle_set_charging_profile_req(Call<SetChargingProfileReque
+
+     response = this->conform_validate_and_add_profile(msg.chargingProfile, msg.evseId);
      if (response.status == ChargingProfileStatusEnum::Accepted) {
 -        EVLOG_debug << "Accepting SetChargingProfileRequest";
 +        EVLOG_info << "Accepting SetChargingProfileRequest";
-         this->callbacks.set_charging_profiles_callback();
+         this->set_charging_profiles_callback();
      } else {
 -        EVLOG_debug << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
 +        EVLOG_info << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
                      << "\nadditionalInfo: " << response.statusInfo->additionalInfo->get();
      }
- 

--- a/manager/dev-build-install-configure.sh
+++ b/manager/dev-build-install-configure.sh
@@ -1,0 +1,7 @@
+/entrypoint.sh run-script compile
+/entrypoint.sh run-script install
+
+echo "Applying Post-Build patches..."
+bash /tmp/demo-patch-scripts/apply-runtime-patches.sh
+
+pushd /tmp && bash ./ocpp201-sp-config.sh && popd

--- a/manager/dev-build-install-configure.sh
+++ b/manager/dev-build-install-configure.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 /entrypoint.sh run-script compile
 /entrypoint.sh run-script install
 

--- a/manager/initial-install.sh
+++ b/manager/initial-install.sh
@@ -1,0 +1,13 @@
+git clone https://github.com/EVerest/everest-core.git
+cd everest-core
+git checkout ${EVEREST_VERSION}
+cd ..
+mkdir -p /ext/scripts
+cp -r everest-core/.ci/build-kit/scripts/* /ext/scripts/
+mv everest-core /ext/source
+bash /tmp/demo-patch-scripts/apply-compile-patches.sh
+
+echo "Installing python to allow the power_curve to run"
+pip install --break-system-packages numpy==2.1.3
+pip install --break-system-packages control==0.10.1
+pip install --break-system-packages paho-mqtt==2.1.0

--- a/manager/initial-install.sh
+++ b/manager/initial-install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 git clone https://github.com/EVerest/everest-core.git
 cd everest-core
 git checkout ${EVEREST_VERSION}

--- a/manager/initial-install.sh
+++ b/manager/initial-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 git clone https://github.com/EVerest/everest-core.git
 cd everest-core
-git checkout ${EVEREST_VERSION}
+git checkout "${EVEREST_VERSION}"
 cd ..
 mkdir -p /ext/scripts
 cp -r everest-core/.ci/build-kit/scripts/* /ext/scripts/

--- a/manager/ocpp201-sp-config.sh
+++ b/manager/ocpp201-sp-config.sh
@@ -1,0 +1,28 @@
+echo "Applying generic OCPP configuration with ${DEMO_VERSION} and ${CSMS_SP1_URL}"
+if [[ "$DEMO_VERSION" =~ sp1 || "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
+    cp /tmp/config-sil-ocpp201-pnc.yaml /ext/source/config/config-sil-ocpp201-pnc.yaml
+    rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/EVSE_2.json
+    rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/Connector_2_1.json
+fi
+
+if [[ "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
+  cp /tmp/cached_certs_correct_name_emaid.tar.gz /ext/source/build
+  pushd /ext/source/build && tar xf cached_certs_correct_name_emaid.tar.gz
+
+  echo "Configured everest certs, validating that the chain is set up correctly"
+  openssl verify -show_chain -CAfile dist/etc/everest/certs/ca/v2g/V2G_ROOT_CA.pem --untrusted dist/etc/everest/certs/ca/csms/CPO_SUB_CA1.pem --untrusted dist/etc/everest/certs/ca/csms/CPO_SUB_CA2.pem dist/etc/everest/certs/client/csms/CSMS_LEAF.pem
+  popd
+fi
+
+if [[ "$DEMO_VERSION" =~ sp1 ]]; then
+    echo "Configured to SecurityProfile: 1, disabling TLS and configuring server to ${CSMS_SP1_URL}"
+    sed -i "s#ws://localhost:9000#${CSMS_SP1_URL}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+    pushd /ext/source && patch -p0 -i /tmp/disable_iso_tls.patch && popd
+elif [[ "$DEMO_VERSION" =~ sp2 ]]; then
+    echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP2_URL}"
+    sed -i 's#ws://localhost:9000#${CSMS_SP2_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+elif [[ "$DEMO_VERSION" =~ sp3 ]]; then
+    echo "Running with SP3, TLS should be enabled"
+    echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP3_URL}"
+    sed -i 's#ws://localhost:9000#${CSMS_SP3_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+fi

--- a/manager/ocpp201-sp-config.sh
+++ b/manager/ocpp201-sp-config.sh
@@ -1,4 +1,5 @@
-echo "Applying generic OCPP configuration with ${DEMO_VERSION} and ${CSMS_SP1_URL}"
+#!/bin/bash
+echo "Applying generic OCPP configuration with ${DEMO_VERSION}, ${CSMS_SP1_BASE} and ${CHARGE_STATION_ID}"
 if [[ "$DEMO_VERSION" =~ sp1 || "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
     cp /tmp/config-sil-ocpp201-pnc.yaml /ext/source/config/config-sil-ocpp201-pnc.yaml
     rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/EVSE_2.json
@@ -15,14 +16,23 @@ if [[ "$DEMO_VERSION" =~ sp2 || "$DEMO_VERSION" =~ sp3 ]]; then
 fi
 
 if [[ "$DEMO_VERSION" =~ sp1 ]]; then
+    CSMS_SP1_URL=${CSMS_SP1_BASE}/${CHARGE_STATION_ID}
     echo "Configured to SecurityProfile: 1, disabling TLS and configuring server to ${CSMS_SP1_URL}"
     sed -i "s#ws://localhost:9000#${CSMS_SP1_URL}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
     pushd /ext/source && patch -N -p0 -i /tmp/disable_iso_tls.patch && popd
 elif [[ "$DEMO_VERSION" =~ sp2 ]]; then
+    CSMS_SP2_URL=${CSMS_SP2_BASE}/${CHARGE_STATION_ID}
     echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP2_URL}"
-    sed -i 's#ws://localhost:9000#${CSMS_SP2_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+    sed -i "s#ws://localhost:9000#${CSMS_SP2_URL}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
 elif [[ "$DEMO_VERSION" =~ sp3 ]]; then
+    CSMS_SP3_URL=${CSMS_SP3_BASE}/${CHARGE_STATION_ID}
     echo "Running with SP3, TLS should be enabled"
     echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP3_URL}"
-    sed -i 's#ws://localhost:9000#${CSMS_SP3_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+    sed -i "s#ws://localhost:9000#${CSMS_SP3_URL}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+fi
+
+if [[ "$CHARGE_STATION_ID" != cp001 ]]; then
+    echo "Found non-standard CHARGE_STATION_ID ${CHARGE_STATION_ID}, replacing in InternalCtrlr.json and SecurityCtrlr.json"
+    sed -i "s#cp001#${CHARGE_STATION_ID}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
+    sed -i "s#cp001#${CHARGE_STATION_ID}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/SecurityCtrlr.json
 fi

--- a/manager/ocpp201-sp-config.sh
+++ b/manager/ocpp201-sp-config.sh
@@ -17,7 +17,7 @@ fi
 if [[ "$DEMO_VERSION" =~ sp1 ]]; then
     echo "Configured to SecurityProfile: 1, disabling TLS and configuring server to ${CSMS_SP1_URL}"
     sed -i "s#ws://localhost:9000#${CSMS_SP1_URL}#" /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json
-    pushd /ext/source && patch -p0 -i /tmp/disable_iso_tls.patch && popd
+    pushd /ext/source && patch -N -p0 -i /tmp/disable_iso_tls.patch && popd
 elif [[ "$DEMO_VERSION" =~ sp2 ]]; then
     echo "Configured to SecurityProfile: 2, configuring server to  ${CSMS_SP2_URL}"
     sed -i 's#ws://localhost:9000#${CSMS_SP2_URL}#' /ext/dist/share/everest/modules/OCPP201/component_config/standardized/InternalCtrlr.json

--- a/manager/os-pkg-install.sh
+++ b/manager/os-pkg-install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 apt-get -y -qq update
 apt-get install -y -qq patch
 apt-get install -y -qq vim

--- a/manager/os-pkg-install.sh
+++ b/manager/os-pkg-install.sh
@@ -1,0 +1,3 @@
+apt-get -y -qq update
+apt-get install -y -qq patch
+apt-get install -y -qq vim

--- a/manager/run-test.sh
+++ b/manager/run-test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #! /bin/sh
 pip install pytest
 pytest --everest-prefix ../build/dist core_tests/startup_tests.py 


### PR DESCRIPTION
- Use the new arm64-specific image from @catarial
- Remove all `linux/x86_64` platform links
- Change the build to specify platforms manually (only arm64 for now since the amd64 build fails without Rosetta https://github.com/EVerest/everest-demo/issues/113#issuecomment-2859597636)
- Modify the patches to work with the new codebase
    - Change the path to the library files
    - Switch the class/namespace structure

At this point, everything compiles and runs without error on amd64. However, the charge session fails with
https://github.com/EVerest/everest-demo/issues/103 (https://github.com/EVerest/everest-demo/issues/113#issuecomment-2862013383)

Going to improve the dev workflow before fixing that, and adding other patches for the notify_limit