### PR TITLE
🔧 Switch to single phase AC for the demo

### DIFF
--- a/manager/config-sil-ocpp201-pnc.yaml
+++ b/manager/config-sil-ocpp201-pnc.yaml
@@ -54,7 +54,7 @@ active_modules:
       auto_enable: true
       auto_exec: false
       auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
-      three_phases: true
+      three_phases: false
     connections:
       ev_board_support:
         - module_id: yeti_driver_1

--- a/manager/demo-patch-scripts/apply-compile-patches.sh
+++ b/manager/demo-patch-scripts/apply-compile-patches.sh
@@ -4,3 +4,4 @@ echo "Applying compile-time patches"
 
 cd / && patch -N -p0 -i /tmp/demo-patches/enable_iso_dt.patch
 cd / && patch -N -p1 -i /tmp/demo-patches/composite_schedule_fixes.patch
+cd / && patch -N -p1 -i /tmp/demo-patches/switch_to_single_phase.patch

--- a/manager/demo-patches/switch_to_single_phase.patch
+++ b/manager/demo-patches/switch_to_single_phase.patch
@@ -1,0 +1,15 @@
+diff --git a/modules/EvseManager/EvseManager.cpp b/modules/EvseManager/EvseManager.cpp
+index 75fe2062..d5aaf448 100644
+--- a/ext/source/modules/EvseManager/EvseManager.cpp
++++ b/ext/source/modules/EvseManager/EvseManager.cpp
+@@ -262,8 +262,8 @@ void EvseManager::ready() {
+
+             // FIXME: we cannot change this during run time at the moment. Refactor ISO interface to exclude transfer
+             // modes from setup
+-            // transfer_modes.push_back(types::iso15118::EnergyTransferMode::AC_single_phase_core);
+-            transfer_modes.push_back({types::iso15118::EnergyTransferMode::AC_three_phase_core, support_bidi});
++            transfer_modes.push_back({types::iso15118::EnergyTransferMode::AC_single_phase_core, support_bidi});
++            // transfer_modes.push_back({types::iso15118::EnergyTransferMode::AC_three_phase_core, support_bidi});
+
+         } else if (config.charge_mode == "DC") {
+             transfer_modes.push_back({types::iso15118::EnergyTransferMode::DC_extended, false});


### PR DESCRIPTION
Since we will use this in the US Testival, where we expect to have cars that are set up to accept single phase.

- Configure the hardcoded value in the EVSE
- Change the config to support single phase in the car (EV)