### PR TITLE
🚑️ Fix regression; fill in the `EVSENominalVoltage`

### DIFF
--- a/manager/demo-patches/enable_iso_dt.patch
+++ b/manager/demo-patches/enable_iso_dt.patch
@@ -1,6 +1,8 @@
+diff --git a/ext/source/modules/EvseV2G/iso_server.cpp b/ext/source/modules/EvseV2G/iso_server.cpp
+index fb3110b8..e6b95c0c 100644
 --- /ext/source/modules/EvseV2G/iso_server.cpp
 +++ /ext/source/modules/EvseV2G/iso_server.cpp
-@@ -1130,32 +1130,55 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
+@@ -1171,32 +1171,55 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
      res->EVSEChargeParameter_isUsed = 0;
      res->EVSEProcessing = (iso2_EVSEProcessingType)conn->ctx->evse_v2g_data.evse_processing[PHASE_PARAMETER];
  
@@ -64,7 +66,7 @@
              conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                  .PMaxSchedule.PMaxScheduleEntry.array[0]
                  .RelativeTimeInterval.start = 0;
-@@ -1164,7 +1187,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
+@@ -1205,7 +1228,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
                  .RelativeTimeInterval.duration_isUsed = 1;
              conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                  .PMaxSchedule.PMaxScheduleEntry.array[0]
@@ -73,15 +75,13 @@
              conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                  .PMaxSchedule.PMaxScheduleEntry.arrayLen = 1;
              conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.arrayLen = 1;
-@@ -1212,14 +1235,8 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
-         populate_physical_value_float(&res->AC_EVSEChargeParameter.EVSEMaxCurrent, max_current, 1,
-                                       iso2_unitSymbolType_A);
+@@ -1255,12 +1278,9 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
  
--        /* Nominal voltage */
--        res->AC_EVSEChargeParameter.EVSENominalVoltage = conn->ctx->evse_v2g_data.evse_nominal_voltage;
+         /* Nominal voltage */
+         res->AC_EVSEChargeParameter.EVSENominalVoltage = conn->ctx->evse_v2g_data.evse_nominal_voltage;
 -        int64_t nom_voltage = conn->ctx->evse_v2g_data.evse_nominal_voltage.Value *
 -                              pow(10, conn->ctx->evse_v2g_data.evse_nominal_voltage.Multiplier);
--
+ 
          /* Calculate pmax based on max current, nominal voltage and phase count (which the car has selected above) */
 -        int64_t pmax = max_current * nom_voltage *
 -                       ((iso2_EnergyTransferModeType_AC_single_phase_core == req->RequestedEnergyTransferMode) ? 1 : 3);


### PR DESCRIPTION
While implementing the departure time hack, we removed the nominal voltage population because we already had the nom_voltage but did not put it in anywhere.

This caused it to be populated with a default value of zero hours `EVSENominalVoltage":{"Multiplier":0,"Unit":"h","Value":0}`

which failed validation.

Simply restoring that change and regenerating the diff fixes the issue

This fixes https://github.com/EVerest/everest-demo/issues/103