### PR TITLE
change dc demo script so new config gets copied

### DIFF
--- a/demo-iso15118-2-dc.sh
+++ b/demo-iso15118-2-dc.sh
@@ -31,9 +31,10 @@ download_demo_file() {
 
 download_demo_file "${DEMO_COMPOSE_FILE_NAME}"
 download_demo_file .env
+download_demo_file manager/config-sil-dc.yaml
 
 docker compose --project-name everest-ac-demo \
-	       --file "${DEMO_DIR}/${DEMO_COMPOSE_FILE_NAME}" up
+	       --file "${DEMO_DIR}/${DEMO_COMPOSE_FILE_NAME}" up -d --wait
 docker cp "${DEMO_DIR}/manager/config-sil-dc.yaml"  everest-ac-demo-manager-1:/ext/source/config/config-sil-dc.yaml
 
 if [[ "$START_OPTION" == "auto" ]]; then


### PR DESCRIPTION
Fixes an issue discovered in https://github.com/EVerest/everest-demo/issues/124

without `-d --wait` on the docker compose command, the script gets stuck on nodered without starting Everest

then the new Everest config needs to be downloaded or else docker cp fails

```
lstat /private/var/folders/72/0q297ld15v9c7tp4_1mlkvmrw82w94/T/tmp.gbKPLRKDJ3/manager: no such file or directory
```