### PR TITLE
specify docker version in readme for ipv6 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Below is a table of demonstrations that are currently available.
 
 ## Install and Set-up
 
-1. Install docker with the following link [Get Docker](https://docs.docker.com/get-docker/)
+1. Install docker with the following link [Get Docker](https://docs.docker.com/get-docker/).
+On MacOS it's possible to have issues with ipv6 not working correctly. Version 4.29 of docker
+desktop is known to work with ipv6, download it [here](https://docs.docker.com/desktop/release-notes/#4290).
 
 2. Ensure that docker is installed by opening your machines terminal and typing
 `docker --version`


### PR DESCRIPTION
Docker version 4.29 is known to work when there are issues with ipv6 on the latest version of docker desktop.

https://github.com/EVerest/everest-demo/issues/136