### PR TITLE
remove --wait for podman compatibility

### DIFF
--- a/demo-iso15118-2-dc.sh
+++ b/demo-iso15118-2-dc.sh
@@ -34,7 +34,7 @@ download_demo_file .env
 download_demo_file manager/config-sil-dc.yaml
 
 docker compose --project-name everest-ac-demo \
-	       --file "${DEMO_DIR}/${DEMO_COMPOSE_FILE_NAME}" up -d --wait
+	       --file "${DEMO_DIR}/${DEMO_COMPOSE_FILE_NAME}" up -d
 docker cp "${DEMO_DIR}/manager/config-sil-dc.yaml"  everest-ac-demo-manager-1:/ext/source/config/config-sil-dc.yaml
 
 if [[ "$START_OPTION" == "auto" ]]; then

--- a/demo-iso15118-2-ocpp-201.sh
+++ b/demo-iso15118-2-ocpp-201.sh
@@ -107,7 +107,7 @@ fi
   echo "CSMS_SP2_BASE:     $CSMS_SP2_BASE"
   echo "CSMS_SP3_BASE:     $CSMS_SP3_BASE"
 
-  if ! docker compose --project-name "${DEMO_CSMS}"-csms up -d --wait; then
+  if ! docker compose --project-name "${DEMO_CSMS}"-csms up -d; then
       echo "Failed to start ${DEMO_CSMS}"
       exit 1
   fi


### PR DESCRIPTION
podman-compose does not support the `--wait` flag. Both demo scripts still work after removing the flag so let's not use it.