### PR TITLE
📌 Pin the version of the firestore image as well

### DIFF
--- a/maeve/docker-compose.yml
+++ b/maeve/docker-compose.yml
@@ -100,7 +100,8 @@ services:
     user: "${UID}:${GID}"
 
   firestore:
-    image: google/cloud-sdk
+    image: google/cloud-sdk:522.0.0
+    platform: linux/amd64
     command:
       - gcloud
       - emulators


### PR DESCRIPTION
Most of the images in the maeve docker compose were pinned, but firestore was not. And of course, unpinned images can get updated in ways that break. https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/559

Pinned to the known working version listed in
https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/559#issue-3079006318 and it works