### PR TITLE
enable ipv6 in docker files

### DIFF
--- a/docker-compose.admin-panel.yml
+++ b/docker-compose.admin-panel.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:c::/64
+          gateway: 2001:db8:c::1
 
 services:
   mqtt-server:

--- a/docker-compose.automated-tests.yml
+++ b/docker-compose.automated-tests.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:2::/64
+          gateway: 2001:db8:2::1
 
 services:
   mqtt-server:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:4::/64
+          gateway: 2001:db8:4::1
 
 services:
   mqtt-server:

--- a/docker-compose.iso15118-dc.yml
+++ b/docker-compose.iso15118-dc.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:5::/64
+          gateway: 2001:db8:5::1
 
 services:
   mqtt-server:

--- a/docker-compose.ocpp201.dev.yml
+++ b/docker-compose.ocpp201.dev.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:6::/64
+          gateway: 2001:db8:6::1
 
 services:
   mqtt-server:

--- a/docker-compose.ocpp201.yml
+++ b/docker-compose.ocpp201.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:7::/64
+          gateway: 2001:db8:7::1
 
 services:
   mqtt-server:

--- a/docker-compose.two-evse.yml
+++ b/docker-compose.two-evse.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:9::/64
+          gateway: 2001:db8:9::1
 
 services:
   mqtt-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: 2001:db8:a::/64
-          gateway: 2001:db8:a::1
+        - subnet: 2001:db8:b::/64
+          gateway: 2001:db8:b::1
 
 services:
   mqtt-server:


### PR DESCRIPTION
In newer versions of docker desktop, ipv6 is not enabled by default. This causes an error in everest as it expects an ipv6 link local address.